### PR TITLE
Drop pointless navigation footers and headers

### DIFF
--- a/source/compatibility/v8compatibility.rst
+++ b/source/compatibility/v8compatibility.rst
@@ -146,9 +146,6 @@ calls. Also, the numerical parameters are now unsigned and no longer
 size\_t. This permits us to store them directly into optimized heap
 structures.
 
-[`manual index <manual.html>`_\ ] [`rsyslog
-site <http://www.rsyslog.com/>`_\ ]
-
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 Copyright © 2013-2014 by `Rainer Gerhards <http://www.gerhards.net/rainer>`_

--- a/source/concepts/messageparser.rst
+++ b/source/concepts/messageparser.rst
@@ -1,5 +1,3 @@
-`rsyslog documentation <manual.html>`_
-
 Message parsers in rsyslog
 ==========================
 

--- a/source/configuration/action/rsconf1_actionexeconlywhenpreviousissuspended.rst
+++ b/source/configuration/action/rsconf1_actionexeconlywhenpreviousissuspended.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $ActionExecOnlyWhenPreviousIsSuspended
 --------------------------------------
 
@@ -36,9 +34,6 @@ undesired results (but you can try it if you like).
 **Sample:**
 
 \*.\* @@primary-syslog.example.com $ActionExecOnlyWhenPreviousIsSuspended on &   @@secondary-1-syslog.example.com    # & is used to have more than one action for &   @@secondary-2-syslog.example.com    # the same selector - the mult-action feature &   /var/log/localbuffer $ActionExecOnlyWhenPreviousIsSuspended off # to re-set it for the next selector 
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_actionresumeinterval.rst
+++ b/source/configuration/action/rsconf1_actionresumeinterval.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $ActionResumeInterval
 ---------------------
 
@@ -25,9 +23,6 @@ after the 10th try, it by default is 60 and after the 100th try it is
 **Sample:**
 
 $ActionResumeInterval 30 
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_dirgroup.rst
+++ b/source/configuration/action/rsconf1_dirgroup.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DirGroup
 ---------
 
@@ -18,9 +16,6 @@ not detected.
 **Sample:**
 
 ``$DirGroup loggroup``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_dirowner.rst
+++ b/source/configuration/action/rsconf1_dirowner.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DirOwner
 ---------
 
@@ -18,9 +16,6 @@ detected.
 **Sample:**
 
 ``$DirOwner loguser``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_dynafilecachesize.rst
+++ b/source/configuration/action/rsconf1_dynafilecachesize.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DynaFileCacheSize
 ------------------
 
@@ -34,9 +32,6 @@ order of appearance.
 **Sample:**
 
 ``$DynaFileCacheSize 100    # a cache of 100 files at most``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_filecreatemode.rst
+++ b/source/configuration/action/rsconf1_filecreatemode.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $FileCreateMode
 ---------------
 
@@ -37,9 +35,6 @@ The following sample is deemed to be a complete rsyslog.conf:
 As you can see, open modes depend on position in the config file. Note
 the first line, which is created with the hardcoded default creation
 mode.
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_filegroup.rst
+++ b/source/configuration/action/rsconf1_filegroup.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $FileGroup
 ----------
 
@@ -17,9 +15,6 @@ processing. Interim changes to the user mapping are not detected.
 **Sample:**
 
 ``$FileGroup loggroup``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_fileowner.rst
+++ b/source/configuration/action/rsconf1_fileowner.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $FileOwner
 ----------
 
@@ -18,9 +16,6 @@ detected.
 **Sample:**
 
 ``$FileOwner loguser``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_gssforwardservicename.rst
+++ b/source/configuration/action/rsconf1_gssforwardservicename.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $GssForwardServiceName
 ----------------------
 
@@ -20,9 +18,6 @@ hostname following "@@" in each selector.
 **Sample:**
 
 ``$GssForwardServiceName rsyslog``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_gssmode.rst
+++ b/source/configuration/action/rsconf1_gssmode.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $GssMode
 --------
 
@@ -19,9 +17,6 @@ encrypted if both sides support it.
 **Sample:**
 
 ``$GssMode Encryption``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_omfileforcechown.rst
+++ b/source/configuration/action/rsconf1_omfileforcechown.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $omfileForceChown
 -----------------
 
@@ -66,9 +64,6 @@ version 4, but may disappear at any time for any version greater than 4.
 **Sample:**
 
 ``$FileOwner loguser $omfileForceChown on``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/cryprov_gcry.rst
+++ b/source/configuration/cryprov_gcry.rst
@@ -1,5 +1,3 @@
-`back to rsyslog module overview <rsyslog_conf_modules.html>`_
-
 libgcrypt Log Crypto Provider (gcry)
 ====================================
 
@@ -98,9 +96,6 @@ keyfile="/secured/path/to/keyfile")
 
 Note that the keyfile can be generated via the rscrytool utility (see its documentation for how to
 actually do that).
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/droppriv.rst
+++ b/source/configuration/droppriv.rst
@@ -49,9 +49,6 @@ wiki <http://wiki.rsyslog.com/index.php/Security#Dropping_Privileges>`_.
    instead of a name is specified. Thus, privilege drop will always
    happen.
 
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
-
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 Copyright © 2008 by `Rainer Gerhards <http://www.gerhards.net/rainer>`_

--- a/source/configuration/global/options/rsconf1_debugprintcfsyslinehandlerlist.rst
+++ b/source/configuration/global/options/rsconf1_debugprintcfsyslinehandlerlist.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DebugPrintCFSyslineHandlerList
 -------------------------------
 
@@ -16,9 +14,6 @@ on. Does not affect operation if debugging is disabled.
 **Sample:**
 
 ````
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_debugprintmodulelist.rst
+++ b/source/configuration/global/options/rsconf1_debugprintmodulelist.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DebugPrintModuleList
 ---------------------
 
@@ -16,9 +14,6 @@ if debugging is disabled.
 **Sample:**
 
 ````
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_debugprinttemplatelist.rst
+++ b/source/configuration/global/options/rsconf1_debugprinttemplatelist.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DebugPrintTemplateList
 -----------------------
 
@@ -16,9 +14,6 @@ operation if debugging is disabled..
 **Sample:**
 
 ````
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_failonchownfailure.rst
+++ b/source/configuration/global/options/rsconf1_failonchownfailure.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $FailOnChownFailure
 -------------------
 
@@ -20,9 +18,6 @@ not have permission. The default is "on".
 **Sample:**
 
 ``$FailOnChownFailure off``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_generateconfiggraph.rst
+++ b/source/configuration/global/options/rsconf1_generateconfiggraph.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $GenerateConfigGraph
 --------------------
 

--- a/source/configuration/global/options/rsconf1_includeconfig.rst
+++ b/source/configuration/global/options/rsconf1_includeconfig.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $IncludeConfig
 --------------
 
@@ -62,9 +60,6 @@ slash:
 from a directory:**
 
 ``$IncludeConfig /etc/rsyslog.d/*.conf``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_mainmsgqueuesize.rst
+++ b/source/configuration/global/options/rsconf1_mainmsgqueuesize.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $MainMsgQueueSize
 -----------------
 
@@ -33,9 +31,6 @@ a 32 bit system.
 **Sample:**
 
 ``$MainMsgQueueSize 100000 # 100,000 may be a value to handle burst traffic``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_maxopenfiles.rst
+++ b/source/configuration/global/options/rsconf1_maxopenfiles.rst
@@ -1,5 +1,3 @@
-`[rsyslog configuration directive overview] <rsyslog_conf_global.html>`_
-
 $MaxOpenFiles
 -------------
 
@@ -35,9 +33,6 @@ warning message in this case.
 For some reason, this settings seems not to work on all platforms. If
 you experience problems, please let us know so that we can (hopefully)
 narrow down the issue.
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_moddir.rst
+++ b/source/configuration/global/options/rsconf1_moddir.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $ModDir
 -------
 
@@ -19,9 +17,6 @@ the path name with a slash, else module loads will fail.
 **Sample:**
 
 ``$ModDir /usr/rsyslog/libs/  # note the trailing slash!``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_modload.rst
+++ b/source/configuration/global/options/rsconf1_modload.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $ModLoad
 --------
 
@@ -25,9 +23,6 @@ The default module directory is ignored in that case.
 **Sample:**
 
 ``$ModLoad ommysql # load MySQL functionality $ModLoad /rsyslog/modules/ompgsql.so # load the postgres module via absolute path``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/global/options/rsconf1_resetconfigvariables.rst
+++ b/source/configuration/global/options/rsconf1_resetconfigvariables.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $ResetConfigVariables
 ---------------------
 
@@ -18,9 +16,6 @@ parameters.
 **Sample:**
 
 ``$ResetConfigVariables``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/input_directives/rsconf1_controlcharacterescapeprefix.rst
+++ b/source/configuration/input_directives/rsconf1_controlcharacterescapeprefix.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $ControlCharacterEscapePrefix
 -----------------------------
 
@@ -23,9 +21,6 @@ releases.
 **Sample:**
 
 ``$EscapeControlCharactersOnReceive #  # as of syslog-protocol``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/input_directives/rsconf1_dropmsgswithmaliciousdnsptrrecords.rst
+++ b/source/configuration/input_directives/rsconf1_dropmsgswithmaliciousdnsptrrecords.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DropMsgsWithMaliciousDnsPTRRecords
 -----------------------------------
 
@@ -21,9 +19,6 @@ DNS name.
 **Sample:**
 
 ``$DropMsgsWithMaliciousDnsPTRRecords on``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/input_directives/rsconf1_droptrailinglfonreception.rst
+++ b/source/configuration/input_directives/rsconf1_droptrailinglfonreception.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $DropTrailingLFOnReception
 --------------------------
 
@@ -20,9 +18,6 @@ what sysklogd does.
 **Sample:**
 
 ``$DropTrailingLFOnRecption on``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/input_directives/rsconf1_escape8bitcharsonreceive.rst
+++ b/source/configuration/input_directives/rsconf1_escape8bitcharsonreceive.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $Escape8BitCharactersOnReceive
 ------------------------------
 
@@ -38,9 +36,6 @@ $ControlCharacterEscapePrefix character (being '#' by default).
 **Sample:**
 
 ``$Escape8BitCharactersOnReceive on``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.rst
+++ b/source/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $EscapeControlCharactersOnReceive
 ---------------------------------
 
@@ -33,9 +31,6 @@ To be compatible to sysklogd, this option must be turned on.
 **Sample:**
 
 ``$EscapeControlCharactersOnReceive on``
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/input_directives/rsconf1_markmessageperiod.rst
+++ b/source/configuration/input_directives/rsconf1_markmessageperiod.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_global.html>`_
-
 $MarkMessagePeriod
 ------------------
 
@@ -25,9 +23,6 @@ been loaded.**
 ``$MarkMessagePeriod  600 # mark messages appear every 10 Minutes``
 
 **Available since:** rsyslog 3.0.0
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/gssapi.rst
+++ b/source/configuration/modules/gssapi.rst
@@ -71,9 +71,6 @@ The picture demonstrate how things work.
 
    rsyslog gssapi support
 
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
-
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 

--- a/source/configuration/modules/imkmsg.rst
+++ b/source/configuration/modules/imkmsg.rst
@@ -41,9 +41,6 @@ is needed to start pulling messages.
 
 $ModLoad imkmsg
 
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
-
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 Copyright © 2008-2009 by `Rainer

--- a/source/configuration/modules/mmanon.rst
+++ b/source/configuration/modules/mmanon.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 IP Address Anonimization Module (mmanon)
 ========================================
 
@@ -109,9 +107,6 @@ insufficient to fulfill legal requirements (if such exist).
 module(load="mmanon") action(type="omfile" file="/path/to/non-anon.log")
 action(type="mmanon" ipv4.bits="12") action(type="omfile"
 file="/path/to/anon.log")
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmcount.rst
+++ b/source/configuration/modules/mmcount.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 mmcount
 =======
 
@@ -46,9 +44,6 @@ mailing list for questions
             $ActionExecOnlyOnceEveryInterval 30
             :ommail:;RSYSLOG_SyslogProtocol23Format
          }
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmfields.rst
+++ b/source/configuration/modules/mmfields.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 Fields Extraction Module (mmfields)
 ===================================
 
@@ -86,9 +84,6 @@ module(load="mmfields") template(name="ftpl" type=string
 string="%$!%\\n") action(type="omfields" separator=":"
 jsonRoot="!mmfields") action(type="omfile" file="/path/to/logfile"
 template="ftpl")
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmjsonparse.rst
+++ b/source/configuration/modules/mmjsonparse.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 Log Message Normalization Module
 ================================
 
@@ -42,9 +40,6 @@ module(load="mmjsonparse") action(type="mmjsonparse")
 The same in legacy format:
 
 $ModLoad mmjsonparse \*.\* :mmjsonparse:
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmnormalize.rst
+++ b/source/configuration/modules/mmnormalize.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 Log Message Normalization Module
 ================================
 
@@ -85,9 +83,6 @@ The same in legacy format:
 
 $ModLoad mmnormalize $mmnormalizeRuleBase /path/to/rulebase.rb \*.\*
 :mmnormalize:
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmpstrucdata.rst
+++ b/source/configuration/modules/mmpstrucdata.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 RFC5424 structured data parsing module (mmpstrucdata)
 =====================================================
 
@@ -75,9 +73,6 @@ This will output:
 As you can seem, you can address each of the individual items. Note that
 the case of the RFC5424 parameter names has been converted to lower
 case.
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmrfc5424addhmac.rst
+++ b/source/configuration/modules/mmrfc5424addhmac.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 mmrfc5424addhmac
 ================
 
@@ -88,9 +86,6 @@ development of a verification tool, please simply email
 **Caveats/Known Bugs:**
 
 -  none
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmsequence.rst
+++ b/source/configuration/modules/mmsequence.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 Number generator and counter module (mmsequence)
 ================================================
 
@@ -142,9 +140,6 @@ called just as an action. The number generated is stored in a variable.
 **Legacy Configuration Directives**:
 
 Not supported.
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/modules/mmutf8fix.rst
+++ b/source/configuration/modules/mmutf8fix.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_modules.html>`_
-
 Fix invalid UTF-8 Sequences (mmutf8fix)
 =======================================
 
@@ -104,9 +102,6 @@ This is mostly the same as the previous sample, but uses
 
   module(load="mmutf8fix") if $fromhost-ip == "10.0.0.1" then
   action(type="mmutf8fix" mode="controlcharacters") # all other actions here...
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/output_channels.rst
+++ b/source/configuration/output_channels.rst
@@ -1,7 +1,3 @@
-This is a part of the rsyslog.conf documentation.
-
-`back <rsyslog_conf.html>`_
-
 Output Channels
 ---------------
 
@@ -62,10 +58,6 @@ writing to a single file. Meanwhile, rsyslogd has been fixed to support
 files larger 2gb, but obviously only on file systems and operating
 system versions that do so. So it can still make sense to enforce a 2gb
 file size limit.
-
-[`manual index <manual.html>`_\ ]
-[`rsyslog.conf <rsyslog_conf.html>`_\ ] [`rsyslog
-site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/ruleset/rsconf1_rulesetcreatemainqueue.rst
+++ b/source/configuration/ruleset/rsconf1_rulesetcreatemainqueue.rst
@@ -89,9 +89,6 @@ the *ruleset()* object in RainerScript config language if you intend
 to use ruleset queues. The configuration is much more straightforward in
 that language and less error-prone.
 
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
-
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 Copyright © 2009-2014 by `Rainer Gerhards <http://www.gerhards.net/rainer>`_

--- a/source/configuration/ruleset/rsconf1_rulesetparser.rst
+++ b/source/configuration/ruleset/rsconf1_rulesetparser.rst
@@ -1,5 +1,3 @@
-`rsyslog.conf configuration directive <rsyslog_conf_global.html>`_
-
 $RulesetParser
 --------------
 
@@ -108,9 +106,6 @@ case), please see the example section on the
 Note the positions of the directives. With the current config language,
 **sequence of statements is very important**. This is ugly, but
 unfortunately the way it currently works.
-
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/proposals/lookup_tables.rst
+++ b/source/proposals/lookup_tables.rst
@@ -238,9 +238,6 @@ To preserve space and, more important, increase cache hit performance,
 equal data values are only stored once, no matter how often a lookup
 index points to them.
 
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
-
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 Copyright © 2013-2014 by `Rainer Gerhards <http://www.gerhards.net/rainer>`_

--- a/source/rainerscript/rainerscript_call.rst
+++ b/source/rainerscript/rainerscript_call.rst
@@ -41,9 +41,6 @@ related links
 -  `Blog posting announcing "call" statement (with
    sample) <http://blog.gerhards.net/2012/10/how-to-use-rsyslogs-ruleset-and-call.html>`_
 
-[`rsyslog.conf overview <rsyslog_conf.html>`_\ ] [`manual
-index <manual.html>`_\ ] [`rsyslog site <http://www.rsyslog.com/>`_\ ]
-
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 Copyright © 2013-2014 by `Rainer Gerhards <http://www.gerhards.net/rainer>`_

--- a/source/tutorials/high_database_rate.rst
+++ b/source/tutorials/high_database_rate.rst
@@ -1,5 +1,3 @@
-`back <features.html>`_
-
 Handling a massive syslog database insert rate with Rsyslog
 ===========================================================
 
@@ -157,10 +155,6 @@ any later version published by the Free Software Foundation; with no
 Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A
 copy of the license can be viewed at
 `http://www.gnu.org/copyleft/fdl.html <http://www.gnu.org/copyleft/fdl.html>`_.
-
-[`manual index <manual.html>`_\ ]
-[`rsyslog.conf <rsyslog_conf.html>`_\ ] [`rsyslog
-site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/tutorials/log_rotation_fix_size.rst
+++ b/source/tutorials/log_rotation_fix_size.rst
@@ -1,5 +1,3 @@
-`back <rsyslog_conf_output.html>`_
-
 Log rotation with rsyslog
 =========================
 
@@ -59,10 +57,6 @@ With this approach two files for logging are used, each with a maximum
 size of 50 MB. So we can say we have successfully configured a log
 rotation which satisfies our requirement. We keep the logs at a
 fixed-size level of 100 MB.
-
-[`manual index <manual.html>`_\ ]
-[`rsyslog.conf <rsyslog_conf.html>`_\ ] [`rsyslog
-site <http://www.rsyslog.com/>`_\ ]
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/whitepapers/syslog_protocol.rst
+++ b/source/whitepapers/syslog_protocol.rst
@@ -1,5 +1,3 @@
-`back <features.html>`_
-
 syslog-protocol support in rsyslog
 ==================================
 


### PR DESCRIPTION
Most of the links were broken by the documentation restructuring and
they are no longer necessary as sphinx now automatically creates proper
navigation controls.
