### PR TITLE
fix configuration/modules/imptcp.rst rest syntax

### DIFF
--- a/source/configuration/modules/imptcp.rst
+++ b/source/configuration/modules/imptcp.rst
@@ -41,6 +41,7 @@ These parameters can be used with the "input()" statement. They apply to
 the input they are specified with.
 
 .. function:: AddtlFrameDelimiter <Delimiter>
+
    This directive permits to specify an additional frame delimiter for
    plain tcp syslog. The industry-standard specifies using the LF
    character as frame delimiter. Some vendors, notable Juniper in their


### PR DESCRIPTION
Currently, entire `AddtlFrameDelimiter` function block is bolded. Only function name should be bolded.

doc url : http://www.rsyslog.com/doc/master/configuration/modules/imptcp.html
