### PR TITLE
Correct "UPD" to "UDP"

### DIFF
--- a/source/configuration/modules/imudp.rst
+++ b/source/configuration/modules/imudp.rst
@@ -319,7 +319,7 @@ multiple times.
 Legacy Sample
 ^^^^^^^^^^^^^
 
-This sets up an UPD server on port 514:
+This sets up an UDP server on port 514:
 
 ::
 


### PR DESCRIPTION
Corrects a minor typo, changing "UPD" to "UDP."
