### PR TITLE
mmnormalize (variable, allow_regex, title disambiguation) + rscript (foreach, reset, control-structures) + misc

### DIFF
--- a/source/configuration/modules/mmjsonparse.rst
+++ b/source/configuration/modules/mmjsonparse.rst
@@ -1,5 +1,5 @@
-Log Message Normalization Module
-================================
+Log Message Normalization Module (mmjsonparse)
+==============================================
 
 **Module Name:    mmjsonparse**
 

--- a/source/configuration/modules/mmnormalize.rst
+++ b/source/configuration/modules/mmnormalize.rst
@@ -31,6 +31,14 @@ Note that mmnormalize should only be called once on each message.
 Behaviour is undefined if multiple calls to mmnormalize happen for the
 same message.
 
+**Module Parameters**
+
+-  **allow_regex** [boolean] defaults to "off"
+   Specifies if regex field-type should be allowed. Regex field-type has
+   significantly higher computational overhead compared to other fields, 
+   so it should be avoided when another field-type can achieve the desired 
+   effect. Needs to be "on" for regex field-type to work.
+
 **Action Parameters**:
 
 -  **ruleBase** [word]

--- a/source/configuration/modules/mmnormalize.rst
+++ b/source/configuration/modules/mmnormalize.rst
@@ -1,5 +1,5 @@
-Log Message Normalization Module
-================================
+Log Message Normalization Module (mmnormalize)
+==============================================
 
 **Module Name:    mmnormalize**
 
@@ -49,6 +49,14 @@ same message.
    placed. By default, all parsed properties are merged into root of
    message properties. You can place them under a subtree, instead. You
    can place them in local variables, also, by setting path="$.".
+-  **variable** [word] *(Available since: 8.5.1)*
+   Specifies if a variable insteed of property 'msg' should be used for
+   normalization. A varible can be property, local variable, json-path etc.
+   Please note that **useRawMsg** overrides this parameter, so if **useRawMsg**
+   is set, **variable** will be ignored and raw message will be used.
+
+   
+
 
 **Legacy Configuration Directives**:
 

--- a/source/rainerscript/control_structures.rst
+++ b/source/rainerscript/control_structures.rst
@@ -1,0 +1,48 @@
+Control Structures
+==================
+
+Control structures in RainerScript are similar in semantics to a lot 
+of other mainstream languages such as C, Java, Javascript, Ruby, 
+Bash etc.
+So this section assumes the reader is familier with semantics of such 
+structures, and goes about describing RainerScript implementation in 
+usage-example form rather than by formal-definition and 
+detailed semantics documentation.
+
+RainerScript supports following control structures:
+
+**if**:
+::
+   if ($msg contains "important") then {
+      if ( $. foo != "" ) then set $.foo = $.bar & $.baz;
+      action(type="omfile" file="/var/log/important.log" template="outfmt")
+   }
+
+**if/else-if/else**:
+::
+   if ($msg contains "important") then {
+      set $.foo = $.bar & $.baz;
+      action(type="omfile" file="/var/log/important.log" template="outfmt")
+   } else if ($msg startswith "slow-query:") then {
+      action(type="omfile" file="/var/log/slow_log.log" template="outfmt")
+   } else {
+      set $.foo = $.quux;
+      action(type="omfile" file="/var/log/general.log" template="outfmt")
+   }
+
+**foreach**:
+::
+   foreach ($.quux in $!foo) do {
+      action(type="omfile" file="./rsyslog.out.log" template="quux")
+      foreach ($.corge in $.quux!bar) do {
+         reset $.grault = $.corge;
+         action(type="omfile" file="./rsyslog.out.log" template="grault")
+         if ($.garply != "") then
+             set $.garply = $.garply & ", ";
+         reset $.garply = $.garply & $.grault!baz;
+      }
+   }
+
+**call**: :doc:`rainerscript_call`
+   
+

--- a/source/rainerscript/functions.rst
+++ b/source/rainerscript/functions.rst
@@ -14,7 +14,7 @@ RainerScript supports a currently quite limited set of functions:
 -  wrap(str, wrapper_str, escaper_str) - returns the str wrapped with wrapper_str.
    But additionally, any instances of wrapper_str appearing in str would be replaced
    by the escaper_str. 
-   Eg. wrap("foo.bar", "'", "_") would produce "'foo_bar'"
+   Eg. wrap("foo'bar", "'", "_") would produce "'foo_bar'"
 -  replace(str, substr_to_replace, replace_with) - returns new string with
    all instances of substr_to_replace replaced by replace_with. Eg. 
    replace("foo bar baz", " b", ", B") would return "foo, Bar, Baz".

--- a/source/rainerscript/index.rst
+++ b/source/rainerscript/index.rst
@@ -18,6 +18,7 @@ The first full implementation is available since rsyslog v6.
    data_types
    expressions
    functions
+   control_structures
    configuration_objects
    constant_strings
    variable_property_types


### PR DESCRIPTION
Summary:
- title disambiguation (between mmnormalize and mmjsonparse)
- added docs for mmnormalize allow_regex (module param) and variable (action param)
- dedicated page for rscript control-structures
- detailed docs around behavior of 'set', 'unset' and 'reset'

This patch-set goes after: https://github.com/rsyslog/rsyslog/pull/149 (which in turn, goes after: https://github.com/rsyslog/liblognorm/pull/9)