### PR TITLE
Adding config module documentation for imtcp keep alive options.

### DIFF
--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -52,6 +52,31 @@ Global Parameters
    enable of disable keep-alive packets at the tcp socket layer. The
    default is to disable them.
 
+.. function:: KeepAlive.Probes <number>
+
+   The number of unacknowledged probes to send before considering the
+   connection dead and notifying the application layer. The default, 0,
+   means that the operating system defaults are used. This has only
+   effect if keep-alive is enabled. The functionality may not be
+   available on all platforms.
+
+.. function:: KeepAlive.Interval <number>
+
+   The interval between subsequential keepalive probes, regardless of
+   what the connection has exchanged in the meantime. The default, 0,
+   means that the operating system defaults are used. This has only
+   effect if keep-alive is enabled. The functionality may not be
+   available on all platforms.
+
+.. function:: KeepAlive.Time <number>
+
+   The interval between the last data packet sent (simple ACKs are not
+   considered data) and the first keepalive probe; after the connection
+   is marked to need keepalive, this counter is not used any further.
+   The default, 0, means that the operating system defaults are used.
+   This has only effect if keep-alive is enabled. The functionality may
+   not be available on all platforms.
+
 .. function:: FlowControl on/off
 
    *Default is on*
@@ -188,6 +213,18 @@ Legacy Configuration Directives
 .. function:: $InputTCPServerKeepAlive** <on/**off**>
 
    equivalent to: KeepAlive
+
+.. function:: $InputTCPServerKeepAlive\_probes <number>
+
+   Equivalent to: KeepAlive.Probes
+
+.. function:: $InputTCPServerKeepAlive\_intvl <number>
+
+   Equivalent to: KeepAlive.Interval
+
+.. function:: $InputTCPServerKeepAlive\_time <number>
+
+   Equivalent to: KeepAlive.Time
 
 .. function:: $InputTCPServerRun <port>
 


### PR DESCRIPTION
Added new options to rsyslog in this [pull request](https://github.com/rsyslog/rsyslog/pull/175).  Adding respective documentation.  Is actually mostly just copy pasted from imptcp documentation for same options.