### PR TITLE
MaxSessions and MaxListeners vs. MaxOpenFiles

### DIFF
--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -235,6 +235,10 @@ Caveats/Known Bugs
 -  module always binds to all interfaces
 -  can not be loaded together with `imgssapi <imgssapi.html>`_ (which
    includes the functionality of imtcp)
+-  increasing MaxSessions and MaxListeners doesn't change MaxOpenFiles,
+   consider increasing this global configuration parameter too (on Linux
+   check the actual value for running process by in /proc/PID/limits; default
+   limit on Linux is 1024)
 
 Example
 -------


### PR DESCRIPTION
Administrator should consider increasing MaxOpenFiles in case MaxSessions or MaxListeners were increased.
