### PR TITLE
Documented new action param (action.copyMsg) + some minor restructuring

### DIFF
--- a/source/configuration/actions.rst
+++ b/source/configuration/actions.rst
@@ -117,6 +117,11 @@ General Action Parameters
   also automatically set to "on".
   The default for this setting is the equally-named global
   parameter.
+-  **action.copyMsg** on/*off*
+  Configures action to *copy* the message if *on*. Defaults to
+  *off* (which is how actions have worked traditionally), which
+  causes queue to refer to the original message object, with
+  reference-counting. (Introduced with 8.10.0).
 
 Useful Links
 ------------

--- a/source/configuration/actions.rst
+++ b/source/configuration/actions.rst
@@ -117,7 +117,7 @@ General Action Parameters
   also automatically set to "on".
   The default for this setting is the equally-named global
   parameter.
--  **action.copyMsg** on/*off*
+- **action.copyMsg** on/*off*
   Configures action to *copy* the message if *on*. Defaults to
   *off* (which is how actions have worked traditionally), which
   causes queue to refer to the original message object, with

--- a/source/configuration/basic_structure.rst
+++ b/source/configuration/basic_structure.rst
@@ -169,21 +169,18 @@ obviously all statements after the stop statement are never evaluated.
 Flow Control Statements
 ~~~~~~~~~~~~~~~~~~~~~~~
 
--  **if expr then ... else ...** - conditional execution
--  **stop** - stops processing the current message
--  :doc:`call <../rainerscript/rainerscript_call>` - calls a ruleset
-   (just like a subroutine call)
--  **continue** - a NOP, useful e.g. inside the then part of an if
+Flow control is provided by:
 
-Flow control is also provided by :doc:`filter conditions <filters>`.
+- :doc:`Control Structures <../rainerscript/control_structures>`
+  
+- :doc:`Filter Conditions <filters>`
+  
 
 Data Manipulation Statements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  **set** -
-   `sets <http://www.rsyslog.com/how-to-set-variables-in-rsyslog-v7/>`_
-   a user variable
--  **unset** - deletes a previously set user variable
+Data manipulation is achieved by **set**, **unset** and **reset** statements
+which are :doc:`documented here in detail <../rainerscript/variable_property_types>`.
 
 Inputs
 ------

--- a/source/rainerscript/control_structures.rst
+++ b/source/rainerscript/control_structures.rst
@@ -49,6 +49,21 @@ RainerScript supports following control structures:
       }
    }
 
+Please note that asynchronous-action calls in foreach-statement body should
+almost always set *action.copyMsg* to *on*. This is because action calls within foreach
+usually want to work with the variable loop populates(in the above example, $.quux and $.corge)
+which causes message-mutation and async-action must see message as it was in
+a certain invocation of loop-body, so they must make a copy to keep it safe
+from further modification as iteration continues. For instance, an async-action
+invocation with linked-list based queue would look like:
+
+::
+
+   foreach ($.quux in $!foo) do {
+      action(type="omfile" file="./rsyslog.out.log" template="quux" queue.type="linkedlist" action.copyMsg="on")
+   }
+
+
 **call**: :doc:`rainerscript_call`
    
-
+**continue**: a NOP, useful e.g. inside the then part of an if


### PR DESCRIPTION
- Added doc-fragment for action.copyMsg
- Dedup: Got basic-structure page to point to control-structures page from RainerScript section, which talks about control-flow structures in more detail.
- Dedup: Got basic-structure page to point to set/unset/reset documentation in RainerScript section, which talks about mutating statements in much more detail.
