### PR TITLE
"server" typos in stable-v7 branch

### DIFF
--- a/source/concepts/ns_gtls.rst
+++ b/source/concepts/ns_gtls.rst
@@ -37,7 +37,7 @@ are deployed and it is sufficient proof of authenticy when their
 certificates are signed by the CA the server trusts. This is better than
 anon authentication, but still not recommended. **Known Problems**
 
-Even in x509/fingerprint mode, both the client and sever certificate
+Even in x509/fingerprint mode, both the client and server certificate
 currently must be signed by the same root CA. This is an artifact of the
 underlying GnuTLS library and the way we use it. It is expected that we
 can resolve this issue in the future.

--- a/source/configuration/modules/mmsnmptrapd.rst
+++ b/source/configuration/modules/mmsnmptrapd.rst
@@ -65,7 +65,7 @@ output modules are also available to mmsnmptrapd.
    this tag when it comes to matching incoming messages. It MUST not be
    given, except if two slashes are required for whatever reasons (so
    "tag/" results in a check for "tag//" at the start of the tag field).
--  **$mmsnmptrapdSeverityMapping** [severtiymap]
+-  **$mmsnmptrapdSeverityMapping** [severitymap]
    This specifies the severity mapping table. It needs to be specified
    as a list. Note that due to the current config system **no
    whitespace** is supported inside the list, so be sure not to use any

--- a/source/configuration/modules/omlibdbi.rst
+++ b/source/configuration/modules/omlibdbi.rst
@@ -107,7 +107,7 @@ sure the let us know at
 **Sample:**
 
 The following sample writes all syslog messages to the database
-"syslog\_db" on mysqlsever.example.com. The server is MySQL and being
+"syslog\_db" on mysqlserver.example.com. The server is MySQL and being
 accessed under the account of "user" with password "pwd" (if you have
 empty passwords, just remove the $ActionLibdbiPassword line).
 

--- a/source/configuration/modules/ommongodb.rst
+++ b/source/configuration/modules/ommongodb.rst
@@ -36,7 +36,7 @@ used. This template is:
 template(name="BSON" type="string" string="\\"sys\\" : \\"%hostname%\\",
 \\"time\\" : \\"%timereported:::rfc3339%\\", \\"time\_rcvd\\" :
 \\"%timegenerated:::rfc3339%\\", \\"msg\\" : \\"%msg%\\",
-\\"syslog\_fac\\" : \\"%syslogfacility%\\", \\"syslog\_sever\\" :
+\\"syslog\_fac\\" : \\"%syslogfacility%\\", \\"syslog\_server\\" :
 \\"%syslogseverity%\\", \\"syslog\_tag\\" : \\"%syslogtag%\\",
 \\"procid\\" : \\"%programname%\\", \\"pid\\" : \\"%procid%\\",
 \\"level\\" : \\"%syslogpriority-text%\\"")
@@ -56,7 +56,7 @@ field "level" contains the rsyslog property "syslogpriority-text".
 **Sample:**
 
 The following sample writes all syslog messages to the database "syslog"
-and into the collection "log" on mongosever.example.com. The server is
+and into the collection "log" on mongoserver.example.com. The server is
 being accessed under the account of "user" with password "pwd".
 
 ::

--- a/source/configuration/modules/ommysql.rst
+++ b/source/configuration/modules/ommysql.rst
@@ -64,7 +64,7 @@ creating your own custom template.
 **Sample:**
 
 The following sample writes all syslog messages to the database
-"syslog\_db" on mysqlsever.example.com. The server is being accessed
+"syslog\_db" on mysqlserver.example.com. The server is being accessed
 under the account of "user" with password "pwd".
 
 $ModLoad ommysql $ActionOmmysqlServerPort 1234 # use non-standard port

--- a/source/configuration/modules/omrelp.rst
+++ b/source/configuration/modules/omrelp.rst
@@ -124,7 +124,7 @@ be specified. To send a message via RELP, use
 
 ::
 
-  *.*  :omrelp:<sever>:<port>;<template>
+  *.*  :omrelp:<server>:<port>;<template>
 
 just as you use 
 

--- a/source/configuration/modules/omrelp.rst
+++ b/source/configuration/modules/omrelp.rst
@@ -130,7 +130,7 @@ just as you use 
 
 ::
 
-  *.*  @@<sever>:<port>;<template>
+  *.*  @@<server>:<port>;<template>
 
 to forward a message via plain tcp syslog.
 

--- a/source/tutorials/tls.rst
+++ b/source/tutorials/tls.rst
@@ -89,7 +89,7 @@ the server. In short, the setup is as follows:
 **Client**
 
 -  forwards messages via plain tcp syslog using gtls netstream driver to
-   central sever on port 10514
+   central server on port 10514
 
 **Server**
 

--- a/source/tutorials/tls_cert_summary.rst
+++ b/source/tutorials/tls_cert_summary.rst
@@ -129,7 +129,7 @@ In the example, we created a rsyslog certificate authority (CA). Guard
 the CA's files. You need them whenever you need to create a new machine
 certificate. We also saw how to generate the machine certificates
 themselfs and distribute them to the individual machines. Also, you have
-found some configuration samples for a sever, a client and a syslog
+found some configuration samples for a server, a client and a syslog
 relay. Hopefully, this will enable you to set up a similar system in
 many environments.
 


### PR DESCRIPTION
Apart from a trivial merge conflict, this can also be merged to stable-v8.