### PR TITLE
Fix code block in tutorial doc

### DIFF
--- a/source/tutorials/reliable_forwarding.rst
+++ b/source/tutorials/reliable_forwarding.rst
@@ -64,12 +64,15 @@ simple config file, you forward anything you receive to a remote server
 and have buffering applied automatically when it goes down. This must be
 done on the client machine.
 
-$ModLoad imuxsock # local message reception $WorkDirectory /rsyslog/work
-# default location for work (spool) files $ActionQueueType LinkedList #
-use asynchronous processing $ActionQueueFileName srvrfwd # set file
-name, also enables disk mode $ActionResumeRetryCount -1 # infinite
-retries on insert failure $ActionQueueSaveOnShutdown on # save in-memory
-data if rsyslog shuts down \*.\* @@server:port
+.. code-block:: linux-config
+
+    $ModLoad imuxsock # local message reception
+    $WorkDirectory /rsyslog/work # default location for work (spool) files
+    $ActionQueueType LinkedList # use asynchronous processing
+    $ActionQueueFileName srvrfwd # set file name, also enables disk mode
+    $ActionResumeRetryCount -1 # infinite retries on insert failure
+    $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down 
+    *.* @@server:port
 
 The port given above is optional. It may not be specified, in which case
 you only provide the server name. The "$ActionQueueFileName" is used to
@@ -111,18 +114,26 @@ your system.
 
 A sample for forwarding to two hosts looks like this:
 
-$ModLoad imuxsock # local message reception $WorkDirectory /rsyslog/work
-# default location for work (spool) files # start forwarding rule 1
-$ActionQueueType LinkedList # use asynchronous processing
-$ActionQueueFileName srvrfwd1 # set file name, also enables disk mode
-$ActionResumeRetryCount -1 # infinite retries on insert failure
-$ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts
-down \*.\* @@server1:port # end forwarding rule 1 # start forwarding
-rule 2 $ActionQueueType LinkedList # use asynchronous processing
-$ActionQueueFileName srvrfwd2 # set file name, also enables disk mode
-$ActionResumeRetryCount -1 # infinite retries on insert failure
-$ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts
-down \*.\* @@server2 # end forwarding rule 2
+.. code-block:: linux-config
+
+    $ModLoad imuxsock # local message reception
+    $WorkDirectory /rsyslog/work # default location for work (spool) files
+    
+    # start forwarding rule 1
+    $ActionQueueType LinkedList # use asynchronous processing
+    $ActionQueueFileName srvrfwd1 # set file name, also enables disk mode
+    $ActionResumeRetryCount -1 # infinite retries on insert failure
+    $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down
+    *.* @@server1:port
+    # end forwarding rule 1
+    
+    # start forwarding rule 2
+    $ActionQueueType LinkedList # use asynchronous processing
+    $ActionQueueFileName srvrfwd2 # set file name, also enables disk mode
+    $ActionResumeRetryCount -1 # infinite retries on insert failure
+    $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down
+    *.* @@server2
+    # end forwarding rule 2
 
 Note the filename used for the first rule it is "srvrfwd1" and for the
 second it is "srvrfwd2". I have used a server without port name in the


### PR DESCRIPTION
In the docs for [Reliable Forwarding of syslog Messages with Rsyslog](http://www.rsyslog.com/doc/v8-stable/tutorials/reliable_forwarding.html) the code snippets are not formatted properly. I've fix the source file for the docs with what I assume is the correct line breaks. 

I've also used syntax highlighting that is part of a default sphinx installation.

I hope this all makes sense. Let me know if you want me to change anything.