### PR TITLE
Correct typos

### DIFF
--- a/source/concepts/queues.rst
+++ b/source/concepts/queues.rst
@@ -101,7 +101,7 @@ Disk Queues
 ~~~~~~~~~~~
 
 Disk queues use disk drives for buffering. The important fact is that
-the always use the disk and do not buffer anything in memory. Thus, the
+they always use the disk and do not buffer anything in memory. Thus, the
 queue is ultra-reliable, but by far the slowest mode. For regular use
 cases, this queue mode is not recommended. It is useful if log data is
 so important that it must not be lost, even in extreme cases.
@@ -325,7 +325,7 @@ Similarily, a third worker will be started when there are at least 300
 messages, a forth when reaching 400 and so on.
 
 It, however, does not make sense to have too many worker threads running
-in parall. Thus, the upper limit ca be set via
+in parallel. Thus, the upper limit can be set via
 "*$<object>QueueWorkerThreads*\ ". If it, for example, is set to four,
 no more than four workers will ever be started, no matter how many
 elements are enqueued.
@@ -345,7 +345,7 @@ Discarding Messages
 If the queue reaches the so called "discard watermark" (a number of
 queued elements), less important messages can automatically be
 discarded. This is in an effort to save queue space for more important
-messages, which you even less like to loose. Please note that whenever
+messages, which you even less like to lose. Please note that whenever
 there are more than "discard watermark" messages, both newly incoming as
 well as already enqueued low-priority messages are discarded. The
 algorithm discards messages newly coming in and those at the front of

--- a/source/configuration/modules/imjournal.rst
+++ b/source/configuration/modules/imjournal.rst
@@ -15,7 +15,7 @@ journal to syslog.
 
 Note that this module reads the journal database, what is considered a
 relativly performance-intense operation. As such, the performance of a
-configuration utilizing this module may be notably slower then when
+configuration utilizing this module may be notably slower than when
 using `imuxsock <imuxsock.html>`_. The journal provides imuxsock with a
 copy of all "classical" syslog messages, however, it does not provide
 structured data. Only if that structured data is needed, imjournal must be used.

--- a/source/configuration/properties.rst
+++ b/source/configuration/properties.rst
@@ -40,7 +40,7 @@ The following message properties exist:
   possible or DNS resolution has been disabled.
 
 **fromhost-ip**
-  The same as fromhost, but alsways as an IP address. Local inputs (like
+  The same as fromhost, but always as an IP address. Local inputs (like
   imklog) use 127.0.0.1 in this property.
 
 **syslogtag**

--- a/source/rainerscript/queue_parameters.rst
+++ b/source/rainerscript/queue_parameters.rst
@@ -42,7 +42,7 @@ read the :doc:`queues <../concepts/queues>` documentation.
 -  **queue.highwatermark** number
    This applies to disk-assisted queues, only. When the queue fills up
    to this number of messages, the queue begins to spool messages to
-   disk. Please note that this should note happen as part of usual
+   disk. Please note that this should not happen as part of usual
    processing, because disk queue mode is very considerably slower than
    in-memory queue mode. Going to disk should be reserved for cases
    where an output action destination is offline for some period.
@@ -61,7 +61,7 @@ read the :doc:`queues <../concepts/queues>` documentation.
    disk mode for delayable inputs. So this is probably not what you want.
 -  **queue.lightdelaymark** number
 -  **queue.discardmark** number
-   default 9750]
+   default 9750
 -  **queue.discardseverity** number
    \*numerical\* severity! default 8 (nothing discarded)
 -  **queue.checkpointinterval** number

--- a/source/whitepapers/queues_analogy.rst
+++ b/source/whitepapers/queues_analogy.rst
@@ -160,7 +160,7 @@ most, but not all cases.
 
 **Now let's dig a bit into the mathematical properties of turning
 lanes.** We assume that cars all have the same length. So, units of
-cars, the length is alsways one (which is nice, as we don't need to care
+cars, the length is always one (which is nice, as we don't need to care
 about that factor any longer ;)). A turning lane has finite capacity of
 *n* cars. As long as the number of cars wanting to take a turn is less
 than or eqal to *n*, "straigth traffic" is not blocked (or the other way


### PR DESCRIPTION
I corrected some typos here.

I also found that some default values are missing and some parameters are not explained for queues. I think that 9750 is wrong for queue.discardmark. I also couldn't see the dynamic values working for the watermarks, as Changelog suggests for 8.1.2, unless that was reverted.