### PR TITLE
Added note about self-signed certs for omelasticsearch

### DIFF
--- a/source/configuration/modules/omelasticsearch.rst
+++ b/source/configuration/modules/omelasticsearch.rst
@@ -52,6 +52,11 @@ This module provides native support for logging to
 -  **usehttps**\ <on/**off**>
    Send events over HTTPS instead of HTTP. Good for when you have
    Elasticsearch behind Apache or something else that can add HTTPS.
+   Note that if you have a self-signed certificate, you'd need to install
+   it first. This is done by copying the certificate to a trusted path
+   and then running *update-ca-certificates*. That trusted path is
+   typically */usr/local/share/ca-certificates* but check the man page of
+   *update-ca-certificates* for the default path of your distro
 -  **timeout**
    How long Elasticsearch will wait for a primary shard to be available
    for indexing your log before sending back an error. Defaults to "1m".


### PR DESCRIPTION
This note would hopefully clarify how to handle https://github.com/rsyslog/rsyslog/issues/89. I've also tested the solution of installing the self signed certificate on the rsyslog machine and it can send logs to Elasticsearch having an Apache in front of it configured similarly to here: https://github.com/rsyslog/rsyslog/pull/44#issuecomment-46010743