### PR TITLE
Update certtool request per latest version suggestions

### DIFF
--- a/source/tutorials/tls_cert_machine.rst
+++ b/source/tutorials/tls_cert_machine.rst
@@ -47,7 +47,7 @@ unique name. If not, you can not apply proper access control.
 
 ::
 
-    [root@rgf9dev sample]# certtool --generate-privkey --outfile key.pem --bits 2048
+    [root@rgf9dev sample]# certtool --generate-privkey --outfile key.pem --sec-param 2048
     Generating a 2048 bit RSA private key...
     [root@rgf9dev sample]# certtool --generate-request --load-privkey key.pem --outfile request.pem
     Generating a PKCS #10 certificate request...


### PR DESCRIPTION
When running this today you get the following notice:

```shell
example@hostname:/etc/rsyslog.d# certtool --generate-privkey --outfile key.pem --bits 4096
** Note: Please use the --sec-param instead of --bits
Generating a 4096 bit RSA private key...
```

For this reason, I am suggesting the move to `--sec-param` to match the suggestion of the tool.