### PR TITLE
re-word description

### DIFF
--- a/source/configuration/modules/imptcp.rst
+++ b/source/configuration/modules/imptcp.rst
@@ -57,7 +57,8 @@ the input they are specified with.
 
 .. function:: ruleset <name>
 
-   Binds specified ruleset to next server defined.
+   Binds specified ruleset to this input. If not set, the default
+   ruleset is bound.
 
 .. function:: address <name>
 

--- a/source/configuration/modules/imuxsock.rst
+++ b/source/configuration/modules/imuxsock.rst
@@ -119,6 +119,9 @@ Global Parameters
 Input Parameters
 ^^^^^^^^^^^^^^^^
 
+-  **ruleset** [name]
+   Binds specified ruleset to this input. If not set, the default
+   ruleset is bound.
 -  **IgnoreTimestamp** [**on**/off]
    Ignore timestamps included in the message. Applies to the next socket
    being added.


### PR DESCRIPTION
Wording was still based on legacy config format and thus
quite confusing as used.