### PR TITLE
 Fix mistake: indefinite -> discard immediately (v7-stable)

### DIFF
--- a/source/configuration/action/index.rst
+++ b/source/configuration/action/index.rst
@@ -179,7 +179,7 @@ in "direct" mode (no real queue) if not explicitely specified otherwise.
 -  **$ActionQueueTimeoutActionCompletion** <number> [number is timeout in ms
    (1000ms is 1sec!), default 1000, 0 means immediate!]
 -  **$ActionQueueTimeoutEnqueue** <number> [number is timeout in ms (1000ms
-   is 1sec!), default 2000, 0 means indefinite]
+   is 1sec!), default 2000, 0 means discard immediately]
 -  **$ActionQueueTimeoutShutdown** <number> [number is timeout in ms (1000ms
    is 1sec!), default 0 (indefinite)]
 -  **$ActionQueueWorkerTimeoutThreadShutdown** <number> [number is timeout

--- a/source/configuration/global/index.rst
+++ b/source/configuration/global/index.rst
@@ -147,7 +147,7 @@ To understand queue parameters, read
 -  **$MainMsgQueueTimeoutActionCompletion** <number> [number is timeout in
    ms (1000ms is 1sec!), default 1000, 0 means immediate!]
 -  **$MainMsgQueueTimeoutEnqueue** <number> [number is timeout in ms (1000ms
-   is 1sec!), default 2000, 0 means indefinite]
+   is 1sec!), default 2000, 0 means discard immediately]
 -  **$MainMsgQueueTimeoutShutdown** <number> [number is timeout in ms
    (1000ms is 1sec!), default 0 (indefinite)]
 -  **$MainMsgQueueWorkerTimeoutThreadShutdown** <number> [number is timeout


### PR DESCRIPTION
`$<object>QueueTimeoutEnqueue 0` means "discard immediately" and not "indefinite".
For the reference: http://www.rsyslog.com/doc/v7-stable/concepts/queues.html#filled-up-queues