### PR TITLE
Fix: /path/to/state/file -> name-of-state-file

### DIFF
--- a/source/configuration/modules/imfile.rst
+++ b/source/configuration/modules/imfile.rst
@@ -419,7 +419,7 @@ Legacy Configuration Directives
 
 .. index:: 
    single: imfile; $InputFileStateFile
-.. function:: $InputFileStateFile /path/to/state/file
+.. function:: $InputFileStateFile name-of-state-file
 
    equivalent to: "StateFile"
 


### PR DESCRIPTION
Fix misleading comment