### PR TITLE
Correct default value for $MaxMessageSize

### DIFF
--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -77,7 +77,7 @@ The following parameters can be set:
 
 - **maxMessageSize**
 
-  The maximum message size rsyslog can process. Default is 4K. Anything
+  The maximum message size rsyslog can process. Default is 8K. Anything
   above the maximum size will be truncated.
 
 .. _global_janitorInterval:


### PR DESCRIPTION
Hello

In the source file runtime/glbl.c, iMaxLine is set to 8192.

Regards/