### PR TITLE
Update omhiredis.rst

### DIFF
--- a/source/configuration/modules/omhiredis.rst
+++ b/source/configuration/modules/omhiredis.rst
@@ -52,7 +52,7 @@ is meaningless.
   action(
     name="count_programs"
     server="my-redis-server.example.com"
-    port="6379"
+    serverport="6379"
     type="omhiredis"
     mode="template"
     template="program_count_tmpl")
@@ -79,7 +79,7 @@ the plugin will default to the RSYSLOG_ForwardFormat template.
   action(
     name="push_redis"
     server="my-redis-server.example.com"
-    port="6379"
+    serverport="6379"
     type="omhiredis"
     mode="queue"
     key="my_queue")
@@ -106,7 +106,7 @@ will default to the RSYSLOG_ForwardFormat template.
   action(
     name="publish_redis"
     server="my-redis-server.example.com"
-    port="6379"
+    serverport="6379"
     type="omhiredis"
     mode="publish"
     key="my_channel")


### PR DESCRIPTION
Examples are showing _port_, while documentation states (and plugin requires) _serverport_.
Just cosmetic