### PR TITLE
Add notice about rawmsg escaping control characters

### DIFF
--- a/source/configuration/properties.rst
+++ b/source/configuration/properties.rst
@@ -24,9 +24,10 @@ The following message properties exist:
   the MSG part of the message (aka "the message" ;))
 
 **rawmsg**
-  the message excactly as it was received from the socket. Should be
-  useful for debugging. It is also useful if a message should be
-  forwarded totally unaltered.
+  the message "as is".  Should be useful for debugging and also if a message
+  should be forwarded totally unaltered.
+  Please notice *EscapecontrolCharactersOnReceive* is enabled by default, so
+  it may be different from what was received in the socket.
 
 **rawmsg-after-pri**
   Almost the same as **rawmsg**, but the syslog PRI is removed.


### PR DESCRIPTION
Added notice about rawmsg being processed to escape control characters, fixing https://github.com/rsyslog/rsyslog/issues/1159