### PR TITLE
Add description for bind-to-device option

### DIFF
--- a/source/configuration/modules/imudp.rst
+++ b/source/configuration/modules/imudp.rst
@@ -126,6 +126,15 @@ Input Parameters
 
    Array of ports: Port=["514","515","10514","..."]
 
+.. function::  Device <device>
+
+   *Default: none*
+
+   Bind socket to given device (e.g., eth0)
+
+   For Linux with VRF support, the Device option can be used to specify the
+   VRF for the Address.
+
 .. function::  Ruleset <ruleset>
 
    *Default: RSYSLOG_DefaultRuleset*
@@ -264,6 +273,13 @@ This sets up an UPD server on port 514:
 
     module(load="imudp") # needs to be done just once
     input(type="imudp" port="514")
+
+This sets up a UDP server on port 514 bound to device eth0:
+
+::
+
+    module(load="imudp") # needs to be done just once
+    input(type="imudp" port="514" device="eth0")
 
 The following sample is mostly equivalent to the first one, but request
 a larger rcvuf size. Note that 1m most probably will not be honored by

--- a/source/configuration/modules/omfwd.rst
+++ b/source/configuration/modules/omfwd.rst
@@ -46,6 +46,13 @@ Action Parameters
    before the action commend. Note that as of 6.3.6, there is no way to
    specify this within the action itself.
 
+-  **Device** [default none]
+
+   Bind socket to given device (e.g., eth0)
+
+   For Linux with VRF support, the Device option can be used to specify the
+   VRF for the Target address.
+
 -  **TCP\_Framing** "traditional" or "octet-counted" [default traditional]
 
    Framing-Mode to be for forwarding. This affects only TCP-based
@@ -281,7 +288,7 @@ TCP port 10514.
 
 ::
 
-  action(type="omfwd" Target="192.168.2.11" Port="10514" Protocol="tcp" )
+  action(type="omfwd" Target="192.168.2.11" Port="10514" Protocol="tcp" Device="eth0")
 
 Legacy Configuration Directives
 -------------------------------


### PR DESCRIPTION
19e5d06f6637 added support for bind-to-device option for omfwd and
imudp modules. Add description for the option.

Signed-off-by: David Ahern <dsa@cumulusnetworks.com>