### PR TITLE
Fix default value for veryRobustZip

### DIFF
--- a/source/configuration/modules/omfile.rst
+++ b/source/configuration/modules/omfile.rst
@@ -195,7 +195,7 @@ selects whether a static or dynamic file (name) shall be written to.
 
 .. function::  veryRobustZip [switch]
 
-   *Default: on*
+   *Default: off*
    
    *Available since: 7.3.0*
 


### PR DESCRIPTION
Correct default value for veryRobustZip parameter according to the [sources](https://github.com/rsyslog/rsyslog/blob/master/tools/omfile.c#L1085)