### PR TITLE
Correct dequeuebatchsize

### DIFF
--- a/source/rainerscript/queue_parameters.rst
+++ b/source/rainerscript/queue_parameters.rst
@@ -34,7 +34,7 @@ read the :doc:`queues <../concepts/queues>` documentation.
    the `rsyslog FAQ: "lower bound for queue
    sizes" <http://www.rsyslog.com/lower-bound-for-queue-sizes/>`_.
 -  **queue.dequeuebatchsize** number
-   default 16
+   default 128
 -  **queue.maxdiskspace** number
    The maximum size that all queue files together will use on disk. Note
    that the actual size may be slightly larger than the configured max,


### PR DESCRIPTION
According to the [sources](https://github.com/rsyslog/rsyslog/blob/master/runtime/queue.c#L1425), default batch size is now 128.