### PR TITLE
First character is in column 1 not 0

### DIFF
--- a/source/configuration/filters.rst
+++ b/source/configuration/filters.rst
@@ -79,7 +79,7 @@ properties, not the replacer is supported). With this filter, each
 properties can be checked against a specified value, using a specified
 compare operation.
 
-A property-based filter must start with a colon **in column 0**. This tells
+A property-based filter must start with a colon **in column 1**. This tells
 rsyslogd that it is the new filter type. The colon must be followed by
 the property name, a comma, the name of the compare operation to carry
 out, another comma and then the value to compare against. This value


### PR DESCRIPTION
See line 212 in the same file where it is correct.
Arguably we start counting at 1 (i know, programmers sometimes start counting at 0).

We may want to change the wording to remove this ambiguous column number completely ("first column"?)