### PR TITLE
imfile: mention "polling" mode is default if $ModLoad is used

### DIFF
--- a/source/configuration/modules/imfile.rst
+++ b/source/configuration/modules/imfile.rst
@@ -112,6 +112,10 @@ Module Parameters
   reason to enable "polling" mode and later versions will most probably
   remove it. 
 
+  Note: if a legacy "$ModLoad" statement is used, the default is *polling*.
+  This default was kept to prevent problems with old configurations. It
+  might change in the future.
+
 .. index::
    single: imfile; readtimeout
 .. function:: readTimeout [seconds]


### PR DESCRIPTION
Thanks to Jon Henry for pointing out this info was missing.

see also https://github.com/rsyslog/rsyslog/issues/1531