### PR TITLE
Fix typo in the omkafka options

### DIFF
--- a/source/configuration/modules/omkafka.rst
+++ b/source/configuration/modules/omkafka.rst
@@ -106,7 +106,7 @@ comma-delimited list of values as shown here:
    must be correct. Otherwise, some errors may occur or some partitions
    may never receive data.
 
-.. function::  partitions.usedFixed [positiveInteger]
+.. function::  partitions.useFixed [positiveInteger]
 
    *Default: none*
 


### PR DESCRIPTION
This was [added as `partitions.usefixed`](https://github.com/rsyslog/rsyslog/commit/98a04073233d94b2e09a07536fec8f0cbe1c66b9) and never changed. The code also seems grammatically right, so adapt the documentation.

I assume the difference in capitalisation is deliberate since it's the same on all the multi-word options?