### PR TITLE
imuxsock doc: Removed legacy format warning from new style content

### DIFF
--- a/source/configuration/modules/imuxsock.rst
+++ b/source/configuration/modules/imuxsock.rst
@@ -271,8 +271,7 @@ The following sample is a configuration where rsyslogd reads the openssh
 log messages via a separate socket, but this socket is created on a
 temporary file system. As rsyslogd starts up before the sshd, it needs
 to create the socket directories, because it otherwise can not open the
-socket and thus not listen to openssh messages. Note that it is vital
-not to place any other socket between the CreatePath and the Socket.
+socket and thus not listen to openssh messages.
 
 ::
 


### PR DESCRIPTION
refs rsyslog/rsyslog-doc#403