### PR TITLE
Update terms, emphasize case-insensitive parameters

### DIFF
--- a/source/configuration/action/rsconf1_actionexeconlywhenpreviousissuspended.rst
+++ b/source/configuration/action/rsconf1_actionexeconlywhenpreviousissuspended.rst
@@ -1,15 +1,15 @@
 $ActionExecOnlyWhenPreviousIsSuspended
 --------------------------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** off
 
 **Description:**
 
-This directive allows to specify if actions should always be executed
+This parameter allows to specify if actions should always be executed
 ("off," the default) or only if the previous action is suspended ("on").
-This directive works hand-in-hand with the multiple actions per selector
+This parameter works hand-in-hand with the multiple actions per selector
 feature. It can be used, for example, to create rules that automatically
 switch destination servers or databases to a (set of) backup(s), if the
 primary server fails. Note that this feature depends on proper
@@ -33,7 +33,7 @@ undesired results (but you can try it if you like).
 
 **Sample:**
 
-\*.\* @@primary-syslog.example.com $ActionExecOnlyWhenPreviousIsSuspended on &   @@secondary-1-syslog.example.com    # & is used to have more than one action for &   @@secondary-2-syslog.example.com    # the same selector - the mult-action feature &   /var/log/localbuffer $ActionExecOnlyWhenPreviousIsSuspended off # to re-set it for the next selector 
+\*.\* @@primary-syslog.example.com $ActionExecOnlyWhenPreviousIsSuspended on &   @@secondary-1-syslog.example.com    # & is used to have more than one action for &   @@secondary-2-syslog.example.com    # the same selector - the mult-action feature &   /var/log/localbuffer $ActionExecOnlyWhenPreviousIsSuspended off # to re-set it for the next selector
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_actionresumeinterval.rst
+++ b/source/configuration/action/rsconf1_actionresumeinterval.rst
@@ -1,7 +1,7 @@
 $ActionResumeInterval
 ---------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** 30
 
@@ -22,7 +22,7 @@ after the 10th try, it by default is 60 and after the 100th try it is
 
 **Sample:**
 
-$ActionResumeInterval 30 
+$ActionResumeInterval 30
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.

--- a/source/configuration/action/rsconf1_dirgroup.rst
+++ b/source/configuration/action/rsconf1_dirgroup.rst
@@ -1,7 +1,7 @@
 $DirGroup
 ---------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 

--- a/source/configuration/action/rsconf1_dirowner.rst
+++ b/source/configuration/action/rsconf1_dirowner.rst
@@ -1,7 +1,7 @@
 $DirOwner
 ---------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 

--- a/source/configuration/action/rsconf1_dynafilecachesize.rst
+++ b/source/configuration/action/rsconf1_dynafilecachesize.rst
@@ -1,13 +1,13 @@
 $DynaFileCacheSize
 ------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** 10
 
 **Description:**
 
-This directive specifies the maximum size of the cache for
+This parameter specifies the maximum size of the cache for
 dynamically-generated file names. Selector lines with dynamic files
 names ('?' indicator) support writing to multiple files with a single
 selector line. This setting specifies how many open file handles should
@@ -26,7 +26,7 @@ is 1.
 
 Numbers are always in decimal. Leading zeros should be avoided (in some
 later version, they may be mis-interpreted as being octal). Multiple
-directives may be given. They are applied to selector lines based on
+parameters may be given. They are applied to selector lines based on
 order of appearance.
 
 **Sample:**

--- a/source/configuration/action/rsconf1_filecreatemode.rst
+++ b/source/configuration/action/rsconf1_filecreatemode.rst
@@ -1,13 +1,13 @@
 $FileCreateMode
 ---------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** 0644
 
 **Description:**
 
-The $FileCreateMode directive allows to specify the creation mode with
+The $FileCreateMode parameter allows to specify the creation mode with
 which rsyslogd creates new files. If not specified, the value 0644 is
 used (which retains backward-compatibility with earlier releases). The
 value given must always be a 4-digit octal number, with the initial
@@ -19,7 +19,7 @@ configuration file to remove any restrictions.
 
 $FileCreateMode may be specified multiple times. If so, it specifies the
 creation mode for all selector lines that follow until the next
-$FileCreateMode directive. Order of lines is vitally important.
+$FileCreateMode parameter. Order of lines is vitally important.
 
 **Sample:**
 

--- a/source/configuration/action/rsconf1_filegroup.rst
+++ b/source/configuration/action/rsconf1_filegroup.rst
@@ -1,7 +1,7 @@
 $FileGroup
 ----------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 

--- a/source/configuration/action/rsconf1_fileowner.rst
+++ b/source/configuration/action/rsconf1_fileowner.rst
@@ -1,7 +1,7 @@
 $FileOwner
 ----------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 

--- a/source/configuration/action/rsconf1_gssforwardservicename.rst
+++ b/source/configuration/action/rsconf1_gssforwardservicename.rst
@@ -1,7 +1,7 @@
 $GssForwardServiceName
 ----------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** host
 

--- a/source/configuration/action/rsconf1_gssmode.rst
+++ b/source/configuration/action/rsconf1_gssmode.rst
@@ -1,7 +1,7 @@
 $GssMode
 --------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** encryption
 

--- a/source/configuration/action/rsconf1_omfileforcechown.rst
+++ b/source/configuration/action/rsconf1_omfileforcechown.rst
@@ -1,13 +1,13 @@
 $omfileForceChown
 -----------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Parameter Values:** boolean (on/off, yes/no)
 
 **Available:** 4.7.0+, 5.3.0-5.8.x, **NOT** available in 5.9.x or higher
 
-**Note: this directive has been removed and is no longer available. The
+**Note: this parameter has been removed and is no longer available. The
 documentation is currently being retained for historical reaons.**
 Expect it to go away at some later stage as well.
 
@@ -28,13 +28,13 @@ to be removed. See Caveats section below for the important implications.
 
 **Caveats:**
 
-This directive tries to fix a problem that actually is outside the scope
+This parameter tries to fix a problem that actually is outside the scope
 of rsyslog. As such, there are a couple of restrictions and situations
 in which it will not work. **Users are strongly encouraged to fix their
-system instead of turning this directive on** - it should only be used
+system instead of turning this parameter on** - it should only be used
 as a last resort.
 
-At least in the following scenario, this directive will fail expectedly:
+At least in the following scenario, this parameter will fail expectedly:
 
 It does not address the situation that someone changes the ownership
 \*after\* rsyslogd has started. Let's, for example, consider a log
@@ -53,12 +53,12 @@ rotation script.
 -  file open fails
 
 Please note that once the privilege drop code is refactored, this
-directive will no longer work, because then privileges will be dropped
+parameter will no longer work, because then privileges will be dropped
 before any action is performed, and thus we will no longer be able to
 chown files that do not belong to the user rsyslogd is configured to run
 under.
 
-So **expect the directive to go away**. It will not be removed in
+So **expect the parameter to go away**. It will not be removed in
 version 4, but may disappear at any time for any version greater than 4.
 
 **Sample:**

--- a/source/configuration/action/rsconf1_repeatedmsgreduction.rst
+++ b/source/configuration/action/rsconf1_repeatedmsgreduction.rst
@@ -1,18 +1,18 @@
 $RepeatedMsgReduction
 ---------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** off
 
 Description
 ^^^^^^^^^^^
 
-This directive models old sysklogd legacy. **Note that many people,
+This parameter models old sysklogd legacy. **Note that many people,
 including the rsyslog authors, consider this to be a misfeature.** See
 *Discussion* below to learn why.
 
-This directive specifies whether or not repeated messages should be
+This parameter specifies whether or not repeated messages should be
 reduced (this is the "Last line repeated n times" feature). If set to
 *on*, repeated messages are reduced. If kept at *off*, every message is
 logged. In very early versions of rsyslog, this was controlled by the
@@ -58,7 +58,7 @@ Discussion
   "last message repeated" format.
 * This is a feature that worked decades ago when logs were small and reviewed
   by a human, it fails badly on high volume logs processed by tools.
-  
+
 Sample
 ^^^^^^
 

--- a/source/configuration/actions.rst
+++ b/source/configuration/actions.rst
@@ -1,7 +1,7 @@
 Actions
 =======
 
-.. index:: ! action 
+.. index:: ! action
 .. _cfgobj_input:
 
 The Action object describe what is to be done with a message. They are
@@ -21,6 +21,8 @@ The action object has different parameters:
 
 General Action Parameters
 -------------------------
+
+Note: parameter names are case-insensitive.
 
 -  **name** word
 

--- a/source/configuration/basic_structure.rst
+++ b/source/configuration/basic_structure.rst
@@ -12,7 +12,7 @@ Quick overview of message flow and objects
 ------------------------------------------
 Messages enter rsyslog with the help of input modules. Then, they are
 passed to a ruleset, where rules are conditionally applied. When a rule
-matches, the message is transferred to an action, which then does 
+matches, the message is transferred to an action, which then does
 something to the message, e.g. writes it to a file, database or
 forwards it to a remote host.
 
@@ -47,7 +47,7 @@ Processing Principles
 - all rules are **always** fully evaluated, no matter if a filter matches
   or not (so we do **not** stop at the first match). If message processing
   shall stop, the "discard" action (represented by the tilde character or the
-  stop command) must explicitly be executed. If discard is executed, 
+  stop command) must explicitly be executed. If discard is executed,
   message processing immediately stops, without evaluating any further rules.
 
 - an action list contains one or many actions
@@ -64,7 +64,7 @@ Processing Principles
 - if legacy format is used (see below), $Action... directives **must** be
   specified in front of the action they are intended to configure
 
-- some config directives automatically refer to their previous values 
+- some config directives automatically refer to their previous values
   after being applied, others not. See the respective doc for details. Be
   warned that this is currently not always properly documented.
 
@@ -96,15 +96,17 @@ concurrently:
    constructs are no longer supported because they are incompatible with
    newer features. These are mentioned in the compatibility docs.
 -  **legacy rsyslog** - these are statements that begin with a dollar
-   sign. They set some configuration parameters and modify e.g. the way
-   actions operate. This is the only format supported in pre-v6 versions
-   of rsyslog. It is still fully supported in v6 and above. Note that
-   some plugins and features may still only be available through legacy
-   format (because plugins need to be explicitly upgraded to use the
-   new style format, and this hasn't happened to all plugins).
+   sign. They set some (case-insensitive) configuration parameters and
+   modify e.g. the way actions operate. This is the only format supported
+   in pre-v6 versions of rsyslog. It is still fully supported in v6 and
+   above. Note that some plugins and features may still only be available
+   through legacy format (because plugins need to be explicitly upgraded
+   to use the new style format, and this hasn't happened to all plugins).
 -  **RainerScript** - the new style format. This is the best and most
-   precise format to be used for more complex cases. The rest of this
-   page assumes RainerScript based rsyslog.conf.
+   precise format to be used for more complex cases. As with the legacy
+   format, RainerScript parameters are also case-insensitive.
+   The rest of this page assumes RainerScript based rsyslog.conf.
+
 
 The rsyslog.conf files consists of statements. For old style (sysklogd &
 legacy rsyslog), lines do matter. For new style (RainerScript) line
@@ -172,9 +174,9 @@ Flow Control Statements
 Flow control is provided by:
 
 - :doc:`Control Structures <../rainerscript/control_structures>`
-  
+
 - :doc:`Filter Conditions <filters>`
-  
+
 
 Data Manipulation Statements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/configuration/config_param_types.rst
+++ b/source/configuration/config_param_types.rst
@@ -36,7 +36,7 @@ following types are used:
   nor permitted (the quotes would become part of the word).
 
 - **character**
-  
+
   A single (printable) character. Must **not** be quoted.
 
 - **boolean**

--- a/source/configuration/global/options/rsconf1_abortonuncleanconfig.rst
+++ b/source/configuration/global/options/rsconf1_abortonuncleanconfig.rst
@@ -1,9 +1,9 @@
-`rsyslog.conf configuration directive <rsyslog_conf_global.html>`_
+`rsyslog.conf configuration parameter <rsyslog_conf_global.html>`_
 
 $AbortOnUncleanConfig
 ----------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Parameter Values:** boolean (on/off, yes/no)
 
@@ -13,7 +13,7 @@ $AbortOnUncleanConfig
 
 **Description:**
 
-This directive permits to prevent rsyslog from running when the
+This parameter permits to prevent rsyslog from running when the
 configuration file is not clean. "Not Clean" means there are errors or
 some other annoyances that rsyslgod reports on startup. This is a
 user-requested feature to have a strict startup mode. Note that with the
@@ -31,7 +31,7 @@ will not be able to send logs, what in the ultimate result could result
 in a system hang on those systems. Also, the local system may hang when
 the local log socket has become full and is not read. There exist many
 such scenarios. As such, it is strongly recommended not to turn on this
-directive.
+parameter.
 
 [`rsyslog site <http://www.rsyslog.com/>`_\ ]
 

--- a/source/configuration/global/options/rsconf1_debugprintcfsyslinehandlerlist.rst
+++ b/source/configuration/global/options/rsconf1_debugprintcfsyslinehandlerlist.rst
@@ -1,7 +1,7 @@
 $DebugPrintCFSyslineHandlerList
 -------------------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** on
 

--- a/source/configuration/global/options/rsconf1_debugprintmodulelist.rst
+++ b/source/configuration/global/options/rsconf1_debugprintmodulelist.rst
@@ -1,7 +1,7 @@
 $DebugPrintModuleList
 ---------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** on
 

--- a/source/configuration/global/options/rsconf1_debugprinttemplatelist.rst
+++ b/source/configuration/global/options/rsconf1_debugprinttemplatelist.rst
@@ -1,7 +1,7 @@
 $DebugPrintTemplateList
 -----------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** on
 

--- a/source/configuration/global/options/rsconf1_failonchownfailure.rst
+++ b/source/configuration/global/options/rsconf1_failonchownfailure.rst
@@ -1,7 +1,7 @@
 $FailOnChownFailure
 -------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** on
 

--- a/source/configuration/global/options/rsconf1_generateconfiggraph.rst
+++ b/source/configuration/global/options/rsconf1_generateconfiggraph.rst
@@ -1,7 +1,7 @@
 $GenerateConfigGraph
 --------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 
@@ -9,19 +9,19 @@ $GenerateConfigGraph
 
 **Description:**
 
-**This directive is currently not supported. We had to disable it when
+**This parameter is currently not supported. We had to disable it when
 we improved the rule engine. It is considerable effort to re-enable it.
 On the other hand, we are about to add a new config system, which will
 make yet another config graph method necessary. As such we have decided
 to currently disable this functionality and re-introduce it when the new
 config system has been instantiated.**
 
-This directive permits to create (hopefully) good-looking visualizations
+This parameter permits to create (hopefully) good-looking visualizations
 of rsyslogd's configuration. It does not affect rsyslog operation. If
-the directive is specified multiple times, all but the last are ignored.
+the parameter is specified multiple times, all but the last are ignored.
 If it is specified, a graph is created. This happens both during a
 regular startup as well a config check run. It is recommended to include
-this directive only for documentation purposes and remove it from a
+this parameter only for documentation purposes and remove it from a
 production configuration.
 
 The graph is not drawn by rsyslog itself. Instead, it uses the great
@@ -43,7 +43,7 @@ so is rather easy:
    to use friendly names with. If you do this, keep the names short.
 #. run rsyslog at least once (either in regular or configuration check
    mode)
-#. remember to remove the $GenerateConfigGraph directive when you no
+#. remember to remove the $GenerateConfigGraph parameter when you no
    longer need it (or comment it out)
 #. change your working directory to where you place the dot file
 #. if you would like to edit the rsyslog-generated file, now is the time
@@ -95,7 +95,7 @@ commented-out last forwarding action activated:
    :alt: rsyslog configuration graph for a default fedora rsyslog.conf
 
    rsyslog configuration graph for a default fedora rsyslog.conf
-   
+
 This is the typical structure for a simple rsyslog configuration. There
 are a couple of actions, each guarded by a filter. Messages run from top
 to bottom and control branches whenever a filter evaluates to true. As
@@ -111,7 +111,7 @@ complex):
 
 .. figure:: rsyslog_confgraph_complex.png
    :align: center
-   :alt: 
+   :alt:
 
 Here, we have a user-defined discard action. You can immediately see
 this because processing branches after the first "builtin-file" action.

--- a/source/configuration/global/options/rsconf1_includeconfig.rst
+++ b/source/configuration/global/options/rsconf1_includeconfig.rst
@@ -1,14 +1,14 @@
 $IncludeConfig
 --------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 
 **Description:**
 
-This directive allows to include other files into the main configuration
-file. As soon as an IncludeConfig directive is found, the contents of
+This parameter allows to include other files into the main configuration
+file. As soon as an IncludeConfig parameter is found, the contents of
 the new file is processed. IncludeConfigs can be nested. Please note
 that from a logical point of view the files are merged. Thus, if the
 include modifies some parameters (e.g. $DynaFileChacheSize), these new

--- a/source/configuration/global/options/rsconf1_mainmsgqueuesize.rst
+++ b/source/configuration/global/options/rsconf1_mainmsgqueuesize.rst
@@ -1,14 +1,14 @@
 $MainMsgQueueSize
 -----------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** 50000 (v8.30.0) - may change
 
 **Description:**
 
 This allows to specify the maximum size of the message queue. This
-directive is only available when rsyslogd has been compiled with
+parameter is only available when rsyslogd has been compiled with
 multithreading support. In this mode, receiver and output modules are
 de-coupled via an in-memory queue. This queue buffers messages when the
 output modules are not capable to process them as fast as they are

--- a/source/configuration/global/options/rsconf1_maxopenfiles.rst
+++ b/source/configuration/global/options/rsconf1_maxopenfiles.rst
@@ -3,7 +3,7 @@ $MaxOpenFiles
 
 **Available Since:** 4.3.0
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** *operating system default*
 

--- a/source/configuration/global/options/rsconf1_moddir.rst
+++ b/source/configuration/global/options/rsconf1_moddir.rst
@@ -1,7 +1,7 @@
 $ModDir
 -------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** system default for user libraries, e.g.
 /usr/local/lib/rsyslog/
@@ -11,7 +11,7 @@ $ModDir
 Provides the default directory in which loadable modules reside. This
 may be used to specify an alternate location that is not based on the
 system default. If the system default is used, there is no need to
-specify this directive. Please note that it is vitally important to end
+specify this parameter. Please note that it is vitally important to end
 the path name with a slash, else module loads will fail.
 
 **Sample:**

--- a/source/configuration/global/options/rsconf1_modload.rst
+++ b/source/configuration/global/options/rsconf1_modload.rst
@@ -1,7 +1,7 @@
 $ModLoad
 --------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 
@@ -15,7 +15,7 @@ lines that reference it.
 
 Modules must be present in the system default destination for rsyslog
 modules. You can also set the directory via the
-`$ModDir <rsconf1_moddir.html>`_ directive.
+`$ModDir <rsconf1_moddir.html>`_ parameter.
 
 If a full path name is specified, the module is loaded from that path.
 The default module directory is ignored in that case.

--- a/source/configuration/global/options/rsconf1_resetconfigvariables.rst
+++ b/source/configuration/global/options/rsconf1_resetconfigvariables.rst
@@ -1,7 +1,7 @@
 $ResetConfigVariables
 ---------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 
@@ -10,7 +10,7 @@ $ResetConfigVariables
 Resets all configuration variables to their default value. Any settings
 made will not be applied to configuration lines following the
 $ResetConfigVariables. This is a good method to make sure no
-side-effects exists from previous directives. This directive has no
+side-effects exists from previous parameters. This parameter has no
 parameters.
 
 **Sample:**

--- a/source/configuration/global/options/rsconf1_umask.rst
+++ b/source/configuration/global/options/rsconf1_umask.rst
@@ -1,13 +1,13 @@
 $UMASK
 ------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:**
 
 **Description:**
 
-The $umask directive allows to specify the rsyslogd processes' umask. If
+The $umask parameter allows to specify the rsyslogd processes' umask. If
 not specified, the system-provided default is used. The value given must
 always be a 4-digit octal number, with the initial digit being zero.
 

--- a/source/configuration/input.rst
+++ b/source/configuration/input.rst
@@ -1,7 +1,7 @@
 Input
 =====
 
-.. index:: ! input 
+.. index:: ! input
 .. _cfgobj_input:
 
 The ``input`` object, as its name suggests, describes message input sources.
@@ -20,12 +20,14 @@ The input object has different parameters:
 General Input Parameters
 ------------------------
 
+Note: parameter names are case-insensitive.
+
 .. function::  type <type-string>
 
    *Mandatory*
 
    The ``<type-string>`` is a string identifying the input module as given
-   it each module's documentation. For example, the 
+   it each module's documentation. For example, the
    :doc:`UDP syslog input <modules/imudp>` is named "imudp".
 
 

--- a/source/configuration/input_directives/rsconf1_allowedsender.rst
+++ b/source/configuration/input_directives/rsconf1_allowedsender.rst
@@ -1,7 +1,7 @@
 $AllowedSender
 --------------
 
-**Type:** input configuration directive
+**Type:** input configuration parameter
 
 **Default:** all allowed
 
@@ -27,7 +27,7 @@ them is:
 
   $AllowedSender <type>, ip[/bits], ip[/bits]
 
-"$AllowedSender" is the directive - it must be written exactly as shown
+"$AllowedSender" is the parameter - it must be written exactly as shown
 and the $ must start at the first column of the line. "<type>" is either "UDP"
 or "TCP" (or "GSS", if this is enabled during compilation).
 It must immediately be followed by the comma, else you will
@@ -35,7 +35,7 @@ receive an error message. "ip[/bits]" is a machine or network ip address
 as in "192.0.2.0/24" or "127.0.0.1". If the "/bits" part is omitted, a
 single host is assumed (32 bits or mask 255.255.255.255). "/0" is not
 allowed, because that would match any sending system. If you intend to
-do that, just remove all $AllowedSender directives. If more than 32 bits
+do that, just remove all $AllowedSender parameters. If more than 32 bits
 are requested with IPv4, they are adjusted to 32. For IPv6, the limit is
 128 for obvious reasons. Hostnames, with and without wildcards, may also
 be provided. If so, the result of revers DNS resolution is used for
@@ -70,7 +70,7 @@ to stick with hard-coded IP addresses wherever possible.
   $AllowedSender UDP, 127.0.0.1, 192.0.2.0/24, [::1]/128, *.example.net, somehost.example.com
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
-project.  
+project.
 Copyright © 2007-2014 by `Rainer Gerhards <http://www.gerhards.net/rainer>`_
 and `Adiscon <http://www.adiscon.com/>`_. Released under the GNU GPL
 version 2 or higher.

--- a/source/configuration/input_directives/rsconf1_controlcharacterescapeprefix.rst
+++ b/source/configuration/input_directives/rsconf1_controlcharacterescapeprefix.rst
@@ -1,7 +1,7 @@
 $ControlCharacterEscapePrefix
 -----------------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** \\
 
@@ -15,7 +15,7 @@ suggested by Internet-Draft syslog-protocol.
 
 **IMPORTANT**: do not use the ' character. This is reserved and will
 most probably be used in the future as a character delimiter. For the
-same reason, the syntax of this directive will probably change in future
+same reason, the syntax of this parameter will probably change in future
 releases.
 
 **Sample:**

--- a/source/configuration/input_directives/rsconf1_dropmsgswithmaliciousdnsptrrecords.rst
+++ b/source/configuration/input_directives/rsconf1_dropmsgswithmaliciousdnsptrrecords.rst
@@ -1,7 +1,7 @@
 $DropMsgsWithMaliciousDnsPTRRecords
 -----------------------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** off
 

--- a/source/configuration/input_directives/rsconf1_droptrailinglfonreception.rst
+++ b/source/configuration/input_directives/rsconf1_droptrailinglfonreception.rst
@@ -1,7 +1,7 @@
 $DropTrailingLFOnReception
 --------------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** on
 

--- a/source/configuration/input_directives/rsconf1_escape8bitcharsonreceive.rst
+++ b/source/configuration/input_directives/rsconf1_escape8bitcharsonreceive.rst
@@ -1,7 +1,7 @@
 $Escape8BitCharactersOnReceive
 ------------------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** off
 
@@ -9,7 +9,7 @@ $Escape8BitCharactersOnReceive
 
 **Description:**
 
-This directive instructs rsyslogd to replace non US-ASCII characters
+This parameter instructs rsyslogd to replace non US-ASCII characters
 (those that have the 8th bit set) during reception of the message. This
 may be useful for some systems. Please note that this escaping breaks
 Unicode and many other encodings. Most importantly, it can be assumed

--- a/source/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.rst
+++ b/source/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.rst
@@ -1,13 +1,13 @@
 $EscapeControlCharactersOnReceive
 ---------------------------------
 
-**Type:** global configuration directive
+**Type:** global configuration parameter
 
 **Default:** on
 
 **Description:**
 
-This directive instructs rsyslogd to replace control characters during
+This parameter instructs rsyslogd to replace control characters during
 reception of the message. The intent is to provide a way to stop
 non-printable messages from entering the syslog system as whole. If this
 option is turned on, all control-characters are converted to a 3-digit

--- a/source/configuration/input_directives/rsconf1_markmessageperiod.rst
+++ b/source/configuration/input_directives/rsconf1_markmessageperiod.rst
@@ -15,7 +15,7 @@ the immark input module.
 So far, there is only one mark message process and any subsequent
 $MarkMessagePeriod overwrites the previous.
 
-**This directive is only available after the immark input module has
+**This parameter is only available after the immark input module has
 been loaded.**
 
 **Sample:**

--- a/source/configuration/modules/im3195.rst
+++ b/source/configuration/modules/im3195.rst
@@ -8,8 +8,10 @@ actual protocol handling.
 
 **Author:**\ Rainer Gerhards <rgerhards@adiscon.com>
 
-Configuration Directives
+Parameters
 ------------------------
+
+Note: parameter names are case-insensitive.
 
 .. function:: $Input3195ListenPort <port>
 

--- a/source/configuration/modules/imfile.rst
+++ b/source/configuration/modules/imfile.rst
@@ -1,7 +1,7 @@
 imfile: Text File Input Module
 ==============================
 
-.. index:: ! imfile 
+.. index:: ! imfile
 
 ===========================  ===========================================================================
 **Module Name:**             **imfile**
@@ -46,14 +46,14 @@ Metadata
 The imfile module supports message metadata. It supports the following
 data items:
 
-- filename 
+- filename
 
   Name of the file where the message originated from. This is most
   useful when using wildcards inside file monitors, because it then
   is the only way to know which file the message originated from.
   The value can be accessed using the %$!metadata!filename% property.
 
-- fileoffset 
+- fileoffset
 
   Offset of the file in bytes at the time the message was read. The
   offset reported is from the **start** of the line.
@@ -104,7 +104,9 @@ parts of that file.
 Module Parameters
 -----------------
 
-.. index:: 
+Note: parameter names are case-insensitive.
+
+.. index::
    single: imfile; mode
 .. function:: mode ["inotify"/"polling"]
 
@@ -118,7 +120,7 @@ Module Parameters
   suggested that users turn on "polling" mode only if they experience
   strange problems in inotify mode. In theory, there should never be a
   reason to enable "polling" mode and later versions will most probably
-  remove it. 
+  remove it.
 
   Note: if a legacy "$ModLoad" statement is used, the default is *polling*.
   This default was kept to prevent problems with old configurations. It
@@ -157,7 +159,7 @@ Module Parameters
   effect should be neglectible, except if a very large number of files is being
   monitored.
 
-.. index:: 
+.. index::
    single: imfile; PollingInterval
 .. function:: PollingInterval seconds
 
@@ -165,10 +167,10 @@ Module Parameters
 
    This setting specifies how often files are to be
    polled for new data. For obvious reasons, it has effect only if
-   imfile is running in polling mode. 
+   imfile is running in polling mode.
    The time specified is in seconds. During each
    polling interval, all files are processed in a round-robin fashion.
-   
+
    A short poll interval provides more rapid message forwarding, but
    requires more system resources. While it is possible, we stongly
    recommend not to set the polling interval to 0 seconds. That will
@@ -184,7 +186,9 @@ Module Parameters
 Input Parameters
 ----------------
 
-.. index:: 
+Note: parameter names are case-insensitive.
+
+.. index::
    single: imfile; File
 .. function:: File [/path/to/file]
 
@@ -193,7 +197,7 @@ Input Parameters
    macros or templates). Note that wildcards are supported at the file
    name level (see **WildCards** below for more details).
 
-.. index:: 
+.. index::
    single: imfile; Tag
 .. function:: Tag [tag:]
 
@@ -202,7 +206,7 @@ Input Parameters
    you would like to see the colon after the tag, you need to specify it
    here (like 'tag="myTagValue:"').
 
-.. index:: 
+.. index::
    single: imfile; Facility
 .. function:: Facility [facility]
 
@@ -210,7 +214,7 @@ Input Parameters
    in textual form (e.g. "local0", "local1", ...) or as numbers (e.g.
    16 for "local0"). Textual form is suggested. Default  is "local0".
 
-.. index:: 
+.. index::
    single: imfile; Severity
 .. function:: Severity [syslogSeverity]
 
@@ -218,7 +222,7 @@ Input Parameters
    in textual   form (e.g. "info", "warning", ...) or as numbers (e.g. 6
    for "info"). Textual form is suggested. Default is "notice".
 
-.. index:: 
+.. index::
    single: imfile; PersistStateInterval
 .. function:: PersistStateInterval [lines]
 
@@ -232,7 +236,7 @@ Input Parameters
    especially when set to a low value. Frequently writing the state file
    is very time consuming.
 
-.. index:: 
+.. index::
    single: imfile; startmsg.regex
 .. function:: startmsg.regex [POSIX ERE regex]
 
@@ -276,7 +280,7 @@ Input Parameters
   monitored.
 
 
-.. index:: 
+.. index::
    single: imfile; readMode
 .. function:: readMode [mode]
 
@@ -295,7 +299,7 @@ Input Parameters
    2 - indented (new log messages start at the beginning of a line. If a
    line starts with a space or tab "\t" it is part of the log message before it)
 
-.. index:: 
+.. index::
    single: imfile; escapeLF
 .. function:: escapeLF [on/off] (requires v7.5.3+)
 
@@ -309,9 +313,9 @@ Input Parameters
    carefully with all associated tools. Please note that if you intend
    to use plain TCP syslog with embedded LF characters, you need to
    enable octet-counted framing.
-   For more details, see Rainer's blog posting on imfile LF escaping. 
+   For more details, see Rainer's blog posting on imfile LF escaping.
 
-.. index:: 
+.. index::
    single: imfile; MaxLinesAtOnce
 .. function:: MaxLinesAtOnce [number]
 
@@ -331,7 +335,7 @@ Input Parameters
    distribution of events when multiple busy files are monitored. For
    *polling* mode, the **default** is 10240.
 
-.. index:: 
+.. index::
    single: imfile; MaxSubmitAtOnce
 .. function:: MaxSubmitAtOnce [number]
 
@@ -342,7 +346,7 @@ Input Parameters
    you do not know what this doc here talks about, this is a good
    indication that you should NOT modify the default.
 
-.. index:: 
+.. index::
    single: imfile;  deleteStateOnFileDelete
 .. function:: deleteStateOnFileDelete [on/off] (requires v8.5.0+)
 
@@ -368,9 +372,9 @@ Input Parameters
    In general, this parameter should only by set if the users
    knows exactly why this is required.
 
-.. index:: 
+.. index::
    single: imfile;  Ruleset
-.. function:: Ruleset <ruleset> 
+.. function:: Ruleset <ruleset>
 
    Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
 
@@ -429,10 +433,10 @@ Input Parameters
    **Default: off**
 
    This is used to tell rsyslog to seek to the end/tail of input files
-   (discard old logs) **at its first start(freshStart)** and process only new 
+   (discard old logs) **at its first start(freshStart)** and process only new
    log messages.
-   
-   When deploy rsyslog to a large number of servers, we may only care about 
+
+   When deploy rsyslog to a large number of servers, we may only care about
    new log messages generated after the deployment. set **freshstartTail**
    to **on** will discard old logs. Otherwise, there may be vast useless
    message burst on the remote central log receiver
@@ -474,9 +478,9 @@ WildCards
 * /var/log/\*/\*.log **works**. *
 
 
-  All matching files in all matching subfolders will work. 
-  Note that this may derease performance in imfile depending on how 
-  many directories and files are being watched dynamically. 
+  All matching files in all matching subfolders will work.
+  Note that this may derease performance in imfile depending on how
+  many directories and files are being watched dynamically.
 
 
 
@@ -499,18 +503,18 @@ defaults instead.
 
 ::
 
-  module(load="imfile" PollingInterval="10") #needs to be done just once 
+  module(load="imfile" PollingInterval="10") #needs to be done just once
 
-  # File 1 
-  input(type="imfile" 
-        File="/path/to/file1" 
+  # File 1
+  input(type="imfile"
+        File="/path/to/file1"
         Tag="tag1"
-        Severity="error" 
-        Facility="local7") 
+        Severity="error"
+        Facility="local7")
 
   # File 2
-  input(type="imfile" 
-        File="/path/to/file2" 
+  input(type="imfile"
+        File="/path/to/file2"
         Tag="tag2")
 
   # ... and so on ... #
@@ -521,19 +525,19 @@ Legacy Configuration
 Note: in order to preserve compatibility with previous versions, the LF escaping
 in multi-line messages is turned off for legacy-configured file monitors
 (the "escapeLF" input parameter). This can cause serious problems. So it is highly
-suggested that new deployments use the new :ref:`input() <cfgobj_input>` configuration 
-object and keep LF escaping turned on. 
+suggested that new deployments use the new :ref:`input() <cfgobj_input>` configuration
+object and keep LF escaping turned on.
 
 Legacy Configuration Directives
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: 
+.. index::
    single: imfile; $InputFileName
 .. function:: $InputFileName /path/to/file
 
    equivalent to "file"
 
-.. index:: 
+.. index::
    single: imfile; $InputFileTag
 .. function:: $InputFileTag tag:
 
@@ -541,60 +545,60 @@ Legacy Configuration Directives
    you would like to see the colon after the tag, you need to specify it
    here (as shown above).
 
-.. index:: 
+.. index::
    single: imfile; $InputFileStateFile
 .. function:: $InputFileStateFile name-of-state-file
 
    equivalent to: "StateFile"
 
-.. index:: 
+.. index::
    single: imfile; $InputFileFacility
 .. function:: $InputFileFacility facility
 
    equivalent to: "Facility"
 
-.. index:: 
+.. index::
    single: imfile; $InputFileSeverity
 .. function:: $InputFileSeverity severity
 
    equivalent to: "Severity"
 
-.. index:: 
+.. index::
    single: imfile; $InputRunFileMonitor
 .. function:: $InputRunFileMonitor
 
    This **activates** the current monitor. It has no parameters. If you
    forget this directive, no file monitoring will take place.
 
-.. index:: 
+.. index::
    single: imfile; $InputFilePollInterval
 
 .. function:: $InputFilePollInterval seconds
 
    equivalent to: "PollingInterval"
 
-.. index:: 
+.. index::
    single: imfile; $InputFilePersistStateInterval
 
 .. function:: $InputFilePersistStateInterval lines
 
    equivalent to: "PersistStateInterval"
 
-.. index:: 
+.. index::
    single: imfile; $InputFileReadMode
 
 .. function:: $InputFileReadMode mode
 
    equivalent to: "ReadMode"
 
-.. index:: 
+.. index::
    single: imfile; $InputFileMaxLinesAtOnce
 
 .. function:: $InputFileMaxLinesAtOnce number
 
    equivalent to: "MaxLinesAtOnce"
 
-.. index:: 
+.. index::
    single: imfile; $InputFileBindRuleset
 
 .. function:: $InputFileBindRuleset ruleset
@@ -612,22 +616,22 @@ defaults instead.
 
 ::
 
-  $ModLoad imfile # needs to be done just once 
-  # File 1 
-  $InputFileName /path/to/file1 
-  $InputFileTag tag1: 
+  $ModLoad imfile # needs to be done just once
+  # File 1
+  $InputFileName /path/to/file1
+  $InputFileTag tag1:
   $InputFileStateFile stat-file1
 
-  $InputFileSeverity error 
-  $InputFileFacility local7 
+  $InputFileSeverity error
+  $InputFileFacility local7
   $InputRunFileMonitor
-  
-  # File 2 
-  $InputFileName /path/to/file2 
+
+  # File 2
+  $InputFileName /path/to/file2
   $InputFileTag tag2:
 
-  $InputFileStateFile stat-file2 
-  $InputRunFileMonitor 
+  $InputFileStateFile stat-file2
+  $InputRunFileMonitor
   # ... and so on ...
   # check for new lines every 10 seconds
   $InputFilePollInterval 10

--- a/source/configuration/modules/imgssapi.rst
+++ b/source/configuration/modules/imgssapi.rst
@@ -18,8 +18,10 @@ instead.
 
    gssapi
 
-Configuration Directives
+Configuration Parameters
 ------------------------
+
+Note: parameter names are case-insensitive.
 
 .. function:: $InputGSSServerRun <port>
 

--- a/source/configuration/modules/imjournal.rst
+++ b/source/configuration/modules/imjournal.rst
@@ -38,9 +38,11 @@ for most use cases. If insufficient, use the parameters described below
 to adjust the permitted volume. **It is strongly recommended to use this
 plugin only if there is hard need to do so.**
 
-**Configuration Directives**:
+**Configuration Parameters**:
 
-**Module Directives**
+**Module Parameters**
+
+Note: parameter names are case-insensitive.
 
 -  **PersistStateInterval** number-of-messages
 
@@ -99,7 +101,7 @@ plugin only if there is hard need to do so.**
 
 -  **usepidfromsystem** [**off**/on]
 
-   Retrieves the trusted systemd parameter, _PID, instead of the user 
+   Retrieves the trusted systemd parameter, _PID, instead of the user
    systemd parameter, SYSLOG_PID, which is the default.
    This option override the "usepid" option.
    This is now deprecated. It is better to use usepid="syslog" instead.
@@ -119,7 +121,7 @@ plugin only if there is hard need to do so.**
       message is parsed without PID number.
 
 -  **IgnoreNonValidStatefile** [**on**/off]
-   
+
    When a corrupted statefile is read imjournal ignores the statefile and continues
    with logging from the beginning of the journal (from its end if IgnorePreviousMessages
    is on). After PersistStateInterval or when rsyslog is stopped invalid statefile
@@ -156,7 +158,9 @@ saving them into /var/log/ceelog.
   action(type="mmjsonparse")
   action(type="omfile" file="/var/log/ceelog" template="CEETemplate")
 
-**Legacy Configuration Directives**:
+**Legacy Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **$imjournalPersistStateInterval**
 

--- a/source/configuration/modules/imkafka.rst
+++ b/source/configuration/modules/imkafka.rst
@@ -41,11 +41,17 @@ comma-delimited list of values as shown here:
 
 Module Parameters
 ^^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
+
 Currently none.
 
 
 Action Parameters
 ^^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
+
 .. function::  broker <Array>
 
    *Default: "localhost:9092"*

--- a/source/configuration/modules/imklog.rst
+++ b/source/configuration/modules/imklog.rst
@@ -6,8 +6,10 @@ engine.
 
 **Author:**\ Rainer Gerhards <rgerhards@adiscon.com>
 
-Configuration Directives
+Configuration Parameters
 ------------------------
+
+Note: parameter names are case-insensitive.
 
 .. function:: $KLogInternalMsgFacility <facility>
 
@@ -55,32 +57,32 @@ Configuration Directives
 
 .. function:: $klogUseSyscallInterface on/off
 
-   Linux only, ignored on other platforms (but may be specified). 
+   Linux only, ignored on other platforms (but may be specified).
    Defaults to off.
 
 .. function:: $klogSymbolsTwice on/off
 
-   Linux only, ignored on other platforms (but may be specified). 
+   Linux only, ignored on other platforms (but may be specified).
    Defaults to off.
 
 .. function:: $klogParseKernelTimestamp on/off
 
-   If enabled and the kernel creates a timestamp for its log messages, 
-   this timestamp will be parsed and converted into regular message time 
-   instead to use the receive time of the kernel message (as in 5.8.x 
-   and before). Default is 'off' to prevent parsing the kernel timestamp, 
-   because the clock used by the kernel to create the timestamps is not 
-   supposed to be as accurate as the monotonic clock required to convert 
-   it. Depending on the hardware and kernel, it can result in message 
-   time differences between kernel and system messages which occurred at 
+   If enabled and the kernel creates a timestamp for its log messages,
+   this timestamp will be parsed and converted into regular message time
+   instead to use the receive time of the kernel message (as in 5.8.x
+   and before). Default is 'off' to prevent parsing the kernel timestamp,
+   because the clock used by the kernel to create the timestamps is not
+   supposed to be as accurate as the monotonic clock required to convert
+   it. Depending on the hardware and kernel, it can result in message
+   time differences between kernel and system messages which occurred at
    same time.
 
 .. function:: $klogKeepKernelTimestamp on/off
 
-   If enabled, this option causes to keep the [timestamp] provided by 
-   the kernel at the begin of in each message rather than to remove it, 
-   when it could be parsed and converted into local time for use as 
-   regular message time. Only used, when $klogParseKernelTimestamp is 
+   If enabled, this option causes to keep the [timestamp] provided by
+   the kernel at the begin of in each message rather than to remove it,
+   when it could be parsed and converted into local time for use as
+   regular message time. Only used, when $klogParseKernelTimestamp is
    on.
 
 Caveats/Known Bugs

--- a/source/configuration/modules/imkmsg.rst
+++ b/source/configuration/modules/imkmsg.rst
@@ -20,7 +20,9 @@ Log messages are parsed as necessary into rsyslog msg\_t structure.
 Continuation lines are parsed as json key/value pairs and added into
 rsyslog's message json representation.
 
-**Configuration Directives**:
+**Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 This module has no configuration directives.
 

--- a/source/configuration/modules/impstats.rst
+++ b/source/configuration/modules/impstats.rst
@@ -29,24 +29,26 @@ right, but it is expected to be a good aid in starting to understand and
 gain information from the pstats logs.
 
 The rsyslog website has an overview of available `rsyslog
-statistic counters <http://rsyslog.com/rsyslog-statistic-counter/>`_. 
+statistic counters <http://rsyslog.com/rsyslog-statistic-counter/>`_.
 When browsing this page, please be sure to take note of which rsyslog
-version is required to provide a specific counter. Counters are 
+version is required to provide a specific counter. Counters are
 continuously being added, and older versions do not support everything.
 
 
-Configuration Directives
+Configuration Parameters
 ------------------------
 
-The configuration directives for this module are designed for tailoring
+The configuration parameters for this module are designed for tailoring
 the method and process for outputting the rsyslog statistics to file.
 
 Module Configuration Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Note: parameter names are case-insensitive.
+
 This module supports module parameters, only.
 
-.. function:: interval\ [seconds] 
+.. function:: interval\ [seconds]
 
    *Default 300 [5minutes]*
 
@@ -95,14 +97,14 @@ This module supports module parameters, only.
    support for structured formats (note the "cee" is actually "project
    lumberjack" logging).
 
-    
+
    The json-elasticsearch format supports the broken ElasticSearch
    JSON implementation.  ES 2.0 no longer supports valid JSON and
    disallows dots inside names.  The "json-elasticsearch" format
    option replaces those dots by the bang ("!") character. So
    "discarded.full" becomes "discarded!full".
    This option is available starting with 8.16.0.
-    
+
 .. function:: log.syslog\ on/off
 
    *Defaults to on*
@@ -206,8 +208,10 @@ maintained:
 -  **nivcsw**
 -  **openfiles** number of file handles used by rsyslog; includes actual files, sockets and others
 
-Legacy Configuration Directives
+Legacy Configuration Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
 
 A limited set of parameters can also be set via the legacy configuration
 syntax. Note that this is intended as an upward compatibility layer, so
@@ -238,11 +242,11 @@ in 10 minute intervals:
 
 ::
 
-  module(load="impstats" 
-         interval="600" 
+  module(load="impstats"
+         interval="600"
          severity="7")
-  
-  # to actually gather the data: 
+
+  # to actually gather the data:
   syslog.=debug /var/log/rsyslog-stats
 
 In the next sample, the default interval of 5 minutes is used. However,

--- a/source/configuration/modules/imptcp.rst
+++ b/source/configuration/modules/imptcp.rst
@@ -27,6 +27,8 @@ subset of the parameters are supported.
 Module Parameters
 ^^^^^^^^^^^^^^^^^
 
+Note: parameter names are case-insensitive.
+
 These parameters can be used with the "module()" statement. They apply
 globaly to all inputs defined by the module.
 
@@ -59,6 +61,8 @@ globaly to all inputs defined by the module.
 
 Input Parameters
 ^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
 
 These parameters can be used with the "input()" statement. They apply to
 the input they are specified with.
@@ -262,9 +266,9 @@ the input they are specified with.
 
    *Default is 0, which turns off rate limiting*
 
-   Specifies the rate-limiting interval in seconds. Set it to a number 
+   Specifies the rate-limiting interval in seconds. Set it to a number
    of seconds (5 recommended) to activate rate-limiting.
-   
+
 .. function:: RateLimit.Burst [number]
 
    *Default is 10,000*
@@ -318,7 +322,7 @@ This sets up a TCP server on port 514:
 
 ::
 
-  module(load="imptcp") # needs to be done just once 
+  module(load="imptcp") # needs to be done just once
   input(type="imptcp" port="514")
 
 This creates a listener that listens on the local loopback
@@ -326,7 +330,7 @@ interface, only.
 
 ::
 
-  module(load="imptcp") # needs to be done just once 
+  module(load="imptcp") # needs to be done just once
   input(type="imptcp" port="514" address="127.0.0.1")
 
 Create a unix domain socket:
@@ -399,6 +403,6 @@ This sets up a TCP server on port 514:
 
 ::
 
-  $ModLoad imptcp # needs to be done just once 
+  $ModLoad imptcp # needs to be done just once
   $InputPTCPServerRun 514
 

--- a/source/configuration/modules/imrelp.rst
+++ b/source/configuration/modules/imrelp.rst
@@ -26,6 +26,8 @@ Clients send messages to the RELP server via omrelp.
 Module Parameters
 ^^^^^^^^^^^^^^^^^
 
+Note: parameter names are case-insensitive.
+
 .. function:: Ruleset <name>
    (requires v7.5.0+)
 
@@ -34,6 +36,8 @@ Module Parameters
 
 Input Parameters
 ^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
 
 .. function:: Port <port>
 
@@ -95,10 +99,10 @@ Input Parameters
    and keep them in sync with GnuTLS - this is even impossible when
    custom GnuTLS changes are made...).
 
-.. function:: tls.permittedPeer 
+.. function:: tls.permittedPeer
 
-   Peer Places access restrictions on this listener. Only peers which 
-   have been listed in this parameter may connect. The validation bases 
+   Peer Places access restrictions on this listener. Only peers which
+   have been listed in this parameter may connect. The validation bases
    on the certificate the remote peer presents.
 
    The *peer* parameter lists permitted certificate fingerprints. Note
@@ -113,11 +117,11 @@ Input Parameters
    ::
 
      tls.permittedPeer=["SHA1:...1", "SHA1:....2"]
-   
+
    To specify just a single peer, you can either specify the string
    directly or enclose it in braces.
 
-.. function:: tls.authMode <mode> 
+.. function:: tls.authMode <mode>
 
    Sets the mode used for mutual authentication.
 
@@ -152,7 +156,7 @@ Input Parameters
    exactly know what you are doing.
 
 .. function:: KeepAlive on/off
-   
+
    enable of disable keep-alive packets at the tcp socket layer. The
    default is to disable them.
 
@@ -214,11 +218,13 @@ This sets up a RELP server on port 20514 with a max message size of 10,000 bytes
 
 ::
 
-  module(load="imrelp") # needs to be done just once 
+  module(load="imrelp") # needs to be done just once
   input(type="imrelp" port="20514" maxDataSize="10k")
 
-Legacy Configuration Directives
+Legacy Configuration Parameters
 -------------------------------
+
+Note: parameter names are case-insensitive.
 
 -  InputRELPServerBindRuleset <name> (available in 6.3.6+) equivalent
    to: RuleSet

--- a/source/configuration/modules/imsolaris.rst
+++ b/source/configuration/modules/imsolaris.rst
@@ -14,8 +14,10 @@ but rsyslog will continue to run.
 
 **Author:** \ Rainer Gerhards <rgerhards@adiscon.com>
 
-Configuration Directives
+Configuration Parameters
 ------------------------
+
+Note: parameter names are case-insensitive.
 
 | functions:: $IMSolarisLogSocketName <name>
 

--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -14,11 +14,13 @@ Configuration Parameters
 Module Parameters
 ^^^^^^^^^^^^^^^^^
 
+Note: parameter names are case-insensitive.
+
 .. function:: AddtlFrameDelimiter <Delimiter>
 
    This directive permits to specify an additional frame delimiter for
    Multiple receivers may be configured by specifying $InputTCPServerRun
-   multiple times. This is available since version 4.3.1, earlier 
+   multiple times. This is available since version 4.3.1, earlier
    versions do NOT support it.
 
 .. function:: DisableLFDelimiter on/off
@@ -113,7 +115,7 @@ Module Parameters
 
    *Default is 200*
 
-   Sets the maximum number of sessions supported. This must be set 
+   Sets the maximum number of sessions supported. This must be set
    before the first $InputTCPServerRun directive
 
 .. function:: StreamDriver.Name <string>
@@ -173,6 +175,8 @@ Module Parameters
 Input Parameters
 ^^^^^^^^^^^^^^^^
 
+Note: parameter names are case-insensitive.
+
 .. function:: Port <port>
 
    Starts a TCP server on selected port
@@ -192,7 +196,7 @@ Input Parameters
    received from.
 
 .. function:: Ruleset <ruleset>
-   
+
    Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
 
 .. function:: SupportOctetCountedFraming on/off
@@ -200,21 +204,21 @@ Input Parameters
    *Default is on*
 
    If set to "on", the legacy octed-counted framing (similar to RFC5425
-   framing) is activated. This should be left unchanged until you know 
-   very well what you do. It may be useful to turn it off, if you know 
-   this framing is not used and some senders emit multi-line messages 
+   framing) is activated. This should be left unchanged until you know
+   very well what you do. It may be useful to turn it off, if you know
+   this framing is not used and some senders emit multi-line messages
    into the message stream.
 
 .. function:: RateLimit.Interval [number]
 
-   Specifies the rate-limiting interval in seconds. Default value is 0, 
+   Specifies the rate-limiting interval in seconds. Default value is 0,
    which turns off rate limiting. Set it to a number of seconds (5
    recommended) to activate rate-limiting.
 
 .. function:: RateLimit.Burst [number]
 
-   Specifies the rate-limiting burst in number of messages. Default is 
-   10,000. 
+   Specifies the rate-limiting burst in number of messages. Default is
+   10,000.
 
 Statistic Counter
 -----------------

--- a/source/configuration/modules/imudp.rst
+++ b/source/configuration/modules/imudp.rst
@@ -1,7 +1,7 @@
 imudp: UDP Syslog Input Module
 ==============================
 
-.. index:: ! imudp 
+.. index:: ! imudp
 
 ===========================  ===========================================================================
 **Module Name:**             **imudp**
@@ -19,10 +19,14 @@ need to be modified as well. Also, SELinux may need additional rules.
 Configuration Parameters
 ------------------------
 
+Note: parameter names are case-insensitive.
+
 .. index:: imudp; module parameters
 
 Module Parameters
 ^^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
 
 .. function::  TimeRequery <nbr-of-times>
 
@@ -111,7 +115,7 @@ Input Parameters
    Local IP address (or name) the UDP server should bind to. Use \"*"
    to bind to all of the machine's addresses.
 
-.. index:: 
+.. index::
    single: imudp; port (input parameter)
 .. function::  Port <port>
 
@@ -134,7 +138,7 @@ Input Parameters
 
    Manages the IP_FREEBIND option on the UDP socket, which allows binding it to
    an IP address that is nonlocal or not (yet) associated to any network interface.
-   
+
    The parameter accepts the following values:
 
    -  0 - does not enable the IP_FREEBIND option on the
@@ -146,7 +150,7 @@ Input Parameters
 
    -  2 - enables the IP_FREEBIND socket option and
       warns when it is used to successfully bind the socket to a nonlocal address.
-   
+
 .. function::  Device <device>
 
    *Default: none*
@@ -163,7 +167,7 @@ Input Parameters
    Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
 
 .. function::  RateLimit.Interval [number]
-   
+
    *Available since: 7.3.1*
 
    *Default: 0*
@@ -382,7 +386,7 @@ Directive                              Equivalent Parameter Requires
 $UDPServerTimeRequery <nbr-of-times>   *TimeRequery*
 $IMUDPSchedulingPolicy <rr/fifo/other> *SchedulingPolicy*   4.7.4+, 5.7.3+, 6.1.3+
 $IMUDPSchedulingPriority <number>      *SchedulingPriority* 4.7.4+, 5.7.3+, 6.1.3+
-$UDPServerAddress <IP>                 Address              
+$UDPServerAddress <IP>                 Address
 $UDPServerRun <port>                   Port
 $InputUDPServerBindRuleset <ruleset>   Ruleset              5.3.2+
 ====================================== ==================== =======================

--- a/source/configuration/modules/imuxsock.rst
+++ b/source/configuration/modules/imuxsock.rst
@@ -68,6 +68,8 @@ Configuration Parameters
 Global Parameters
 ^^^^^^^^^^^^^^^^^
 
+Note: parameter names are case-insensitive.
+
 -  **SysSock.IgnoreTimestamp** [**on**/off]
    Ignore timestamps included in the messages, applies to messages
    received via the system log socket.
@@ -121,6 +123,8 @@ Global Parameters
 
 Input Parameters
 ^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
 
 -  **ruleset** [name]
    Binds specified ruleset to this input. If not set, the default
@@ -290,8 +294,10 @@ The following sample is used activate message annotation and thus
 trusted properties on the system log socket. module(load="imuxsock" #
 needs to be done just once SysSock.Annotate="on")
 
-Legacy Configuration Directives
+Legacy Configuration Parameters
 -------------------------------
+
+Note: parameter names are case-insensitive.
 
 **Legacy directives should NOT be used when writing new configuration files.**
 

--- a/source/configuration/modules/index.rst
+++ b/source/configuration/modules/index.rst
@@ -8,10 +8,10 @@ Consequently, there is a growing number of modules. Here is the entry
 point to their documentation and what they do (list is currently not
 complete)
 
-Please note that each module provides configuration directives, which
-are NOT necessarily being listed below. Also remember, that a modules
-configuration directive (and functionality) is only available if it has
-been loaded (using $ModLoad).
+Please note that each module provides (case-insensitive) configuration
+parameters, which are NOT necessarily being listed below. Also remember,
+that a modules configuration parameter (and functionality) is only
+available if it has been loaded.
 
 It is relatively easy to write a rsyslog module. If none of the
 provided modules solve your need, you may consider writing one or have

--- a/source/configuration/modules/mmanon.rst
+++ b/source/configuration/modules/mmanon.rst
@@ -34,11 +34,15 @@ have been replaced by an IPv4 address. (see also: RFC4291, 2.2.3) 
 
 **Module Configuration Parameters**:
 
+Note: parameter names are case-insensitive.
+
 Currently none.
 
  
 
 **Action Confguration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 Parameters starting with 'IPv4.' will configure IPv4 anonymization,
 while 'IPv6.' parameters do the same for IPv6 anonymization.

--- a/source/configuration/modules/mmdblookup.rst
+++ b/source/configuration/modules/mmdblookup.rst
@@ -11,13 +11,16 @@ MaxMind/GeoIP DB lookup (mmdblookup)
 
 **Description**:
 
-MaxMindDB is the new file format for storing information about IP addresses in a highly 
+MaxMindDB is the new file format for storing information about IP addresses in a highly
 optimized, flexible database format. GeoIP2 Databases are available in the MaxMind DB format.
 
 Plugin author claimed a MaxMindDB vs GeoIP speed around 4 to 6 times.
 
 Module parameters
 *****************
+
+Note: parameter names are case-insensitive.
+
 -  **container** - default "!iplocation" v8.28.0+
 
    Specifies the container to be used to store the fields ammended by
@@ -26,28 +29,30 @@ Module parameters
 Input parameters
 ****************
 
+Note: parameter names are case-insensitive.
+
 -  **key** - default none
 
    Name of field containing IP address.
-   
+
 -  **mmdbfile** - default none
 
    Location of Maxmind DB file.
-   
+
 -  **fields** - default none
 
    Fields that will be appended to processed message. The fields will
    always be appended in the container used by mmdblookup (which may be
    overriden by the "container" parameter on module load).
-   
+
    By default, the maxmindb field name is used for variables. This can
-   be overriden by specifying a custom name between colons at the 
+   be overriden by specifying a custom name between colons at the
    beginnig of the field name. As usual, bang signs denote path levels.
    So for example, if you want to extract "!city!names!en" but rename it
    to "cityname", you can use ":cityname:!city!names!en" as field name.
 
 
-  
+
 Examples
 ********
 

--- a/source/configuration/modules/mmexternal.rst
+++ b/source/configuration/modules/mmexternal.rst
@@ -18,6 +18,8 @@ For details on the interface specification, see rsyslog's source in the
 
 **Action Parameters**:
 
+Note: parameter names are case-insensitive.
+
 -  **binary**
 
    The name of the external message modification plugin to be called. This
@@ -31,7 +33,7 @@ For details on the interface specification, see rsyslog's source in the
   expectations. Check the external plugin documentation for what needs to be used.
 
 - **output**
-  
+
   This is a debug aid. If set, this is a filename where the plugins output
   is logged. Note that the output is also being processed as usual by rsyslog.
   Setting this parameter thus gives insight into the internal processing

--- a/source/configuration/modules/mmfields.rst
+++ b/source/configuration/modules/mmfields.rst
@@ -41,11 +41,15 @@ conditionally used depending on some prerequisites.
 
 **Module Configuration Parameters**:
 
+Note: parameter names are case-insensitive.
+
 Currently none.
 
  
 
 **Action Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **separator** - separatorChar (default ',')
    This is the character used to separate fields. Currently, only a
@@ -72,7 +76,7 @@ Currently none.
 This is a very simple use case where each message is parsed. The default
 separator character of comma is being used.
 
-:: 
+::
 
   module(load="mmfields")
   template(name="ftpl"

--- a/source/configuration/modules/mmjsonparse.rst
+++ b/source/configuration/modules/mmjsonparse.rst
@@ -36,6 +36,8 @@ the format requirements.
 Action Parameters
 ~~~~~~~~~~~~~~~~~
 
+Note: parameter names are case-insensitive.
+
 .. function:: cookie <string>
 
    **Default**: "@cee:"
@@ -94,5 +96,5 @@ To permit parsing messages without cookie, use this action statement::
 
 The same in legacy format::
 
-  $ModLoad mmjsonparse 
+  $ModLoad mmjsonparse
   *.* :mmjsonparse:

--- a/source/configuration/modules/mmnormalize.rst
+++ b/source/configuration/modules/mmnormalize.rst
@@ -34,17 +34,21 @@ same message.
 Module Parameters
 ~~~~~~~~~~~~~~~~~
 
+Note: parameter names are case-insensitive.
+
 .. function:: allow_regex <boolean>
 
    **Default**: off
 
    Specifies if regex field-type should be allowed. Regex field-type has
-   significantly higher computational overhead compared to other fields, 
-   so it should be avoided when another field-type can achieve the desired 
+   significantly higher computational overhead compared to other fields,
+   so it should be avoided when another field-type can achieve the desired
    effect. Needs to be "on" for regex field-type to work.
 
 Action Parameters
 ~~~~~~~~~~~~~~~~~
+
+Note: parameter names are case-insensitive.
 
 .. function:: ruleBase <word>
 
@@ -88,11 +92,13 @@ Action Parameters
    Please note that **useRawMsg** overrides this parameter, so if **useRawMsg**
    is set, **variable** will be ignored and raw message will be used.
 
-   
 
 
-Legacy Configuration Directives
+
+Legacy Configuration Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Note: parameter names are case-insensitive.
 
 -  $mmnormalizeRuleBase <rulebase-file> - equivalent to the "ruleBase"
    parameter.
@@ -145,9 +151,9 @@ The strings from **rule** are put together and are equal to a rulebase with the 
 
   module(load="mmnormalize")
   module(load="imtcp")
-  
+
   input(type="imtcp" port="10514" ruleset="outp")
-  
+
   ruleset(name="outp") {
   	action(type="mmnormalize" rule=["rule=:%host:word% %tag:char-to:\\x3a%: no longer listening on %ip:ipv4%#%port:number%", "rule=:%host:word% %ip:ipv4% user was logged out"])
   	action(type="omfile" File="/tmp/output")

--- a/source/configuration/modules/mmpstrucdata.rst
+++ b/source/configuration/modules/mmpstrucdata.rst
@@ -10,16 +10,20 @@ RFC5424 structured data parsing module (mmpstrucdata)
 **Description**:
 
 The mmpstrucdata parses the structured data of `RFC5424 <https://tools.ietf.org/html/rfc5424>`_ into the message json variable tree. The data parsed, if available, is stored under "jsonRoot!rfc5424-sd!...". Please note that only RFC5424 messages will be processed.
- 
-The difference of RFC5424 is in the message layout: the SYSLOG-MSG part only contains the structured-data part instead of the normal message part. Further down you can find a example of a structured-data part. 
+
+The difference of RFC5424 is in the message layout: the SYSLOG-MSG part only contains the structured-data part instead of the normal message part. Further down you can find a example of a structured-data part.
 
 **Module Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 Currently none.
 
  
 
 **Action Confguration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **jsonRoot** - default "!"
     Specifies into which json container the data shall be parsed to.
@@ -41,7 +45,7 @@ Currently none.
 
 **Samples:**
 
-Below you can find a structured data part of a random message which has three parameters. 
+Below you can find a structured data part of a random message which has three parameters.
 
 ::
 

--- a/source/configuration/modules/mmrfc5424addhmac.rst
+++ b/source/configuration/modules/mmrfc5424addhmac.rst
@@ -27,11 +27,15 @@ mmpstrucdata.
 
 **Module Configuration Parameters**:
 
+Note: parameter names are case-insensitive.
+
 Currently none.
 
  
 
 **Action Confguration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **key**
    The "key" (string) to be used to generate the hmac.

--- a/source/configuration/modules/mmrm1stspace.rst
+++ b/source/configuration/modules/mmrm1stspace.rst
@@ -10,6 +10,8 @@ if it is a space.
 Configuration Parameters
 ------------------------
 
+Note: parameter names are case-insensitive.
+
 Currently none.
 
 Examples

--- a/source/configuration/modules/mmsequence.rst
+++ b/source/configuration/modules/mmsequence.rst
@@ -32,6 +32,8 @@ called just as an action. The number generated is stored in a variable.
 
 **Action Parameters**:
 
+Note: parameter names are case-insensitive.
+
 -  **mode** "random" or "instance" or "key"
 
    Specifies mode of the action. In "random" mode, the module generates
@@ -146,7 +148,9 @@ called just as an action. The number generated is stored in a variable.
                 key=""
             )
 
-**Legacy Configuration Directives**:
+**Legacy Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 Not supported.
 

--- a/source/configuration/modules/mmsnmptrapd.rst
+++ b/source/configuration/modules/mmsnmptrapd.rst
@@ -19,7 +19,7 @@ this:
 
 ::
 
-    logger -t snmptrapd/warning/realhost Host 003c.abcd.ffff in vlan 17 is flapping between port Gi4/1 and port Gi3/2 
+    logger -t snmptrapd/warning/realhost Host 003c.abcd.ffff in vlan 17 is flapping between port Gi4/1 and port Gi3/2
 
 This message modification module will change the tag (removing the
 additional information), hostname and severity (not shown in example),
@@ -27,7 +27,7 @@ so the log entry will look as follows:
 
 ::
 
-    2011-04-21T16:43:09.101633+02:00 realhost snmptrapd: Host 003c.abcd.ffff in vlan 122 is flapping between port Gi4/1 and port Gi3/2 
+    2011-04-21T16:43:09.101633+02:00 realhost snmptrapd: Host 003c.abcd.ffff in vlan 122 is flapping between port Gi4/1 and port Gi3/2
 
 The following logic is applied to all message being processed:
 
@@ -57,7 +57,9 @@ this module, with the help of filters or multiple rulesets and ruleset
 bindings. In short words, all capabilities rsyslog offers to control
 output modules are also available to mmsnmptrapd.
 
-**Configuration Directives**:
+**Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **$mmsnmptrapdTag** [tagname]
 
@@ -91,12 +93,12 @@ warning severities. The default tag is used.
 
 ::
 
-  $ModLoad mmsnmptrapd # needs to be done just once 
-  # ... other module loads and listener setup ... 
-  *.* /path/to/file/with/orignalMessage # this file receives unmodified messages 
-  $mmsnmptrapdSeverityMapping warning/4,error/3 
+  $ModLoad mmsnmptrapd # needs to be done just once
+  # ... other module loads and listener setup ...
+  *.* /path/to/file/with/orignalMessage # this file receives unmodified messages
+  $mmsnmptrapdSeverityMapping warning/4,error/3
   *.* :mmsnmptrapd: # now message is modified
-  *.* /path/to/file/with/modifiedMessage # this file receives modified messages 
+  *.* /path/to/file/with/modifiedMessage # this file receives modified messages
   # ... rest of config ...
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_

--- a/source/configuration/modules/mmutf8fix.rst
+++ b/source/configuration/modules/mmutf8fix.rst
@@ -47,11 +47,15 @@ this ruleset.
 
 **Module Configuration Parameters**:
 
+Note: parameter names are case-insensitive.
+
 Currently none.
 
  
 
 **Action Confguration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **mode** - **utf-8**/controlcharacters
 

--- a/source/configuration/modules/omamqp1.rst
+++ b/source/configuration/modules/omamqp1.rst
@@ -40,6 +40,8 @@ The output plugin has been tested against the following messaging systems:
 
 **Action Parameters**
 
+Note: parameter names are case-insensitive.
+
 -  **host**
    *(Required)* The address of the message bus in *host[:port]* format.
    The port defaults to 5672 if absent. Examples: *"localhost"*,

--- a/source/configuration/modules/omelasticsearch.rst
+++ b/source/configuration/modules/omelasticsearch.rst
@@ -15,17 +15,19 @@ This module provides native support for logging to
 Action Parameters
 -----------------
 
+Note: parameter names are case-insensitive.
+
 .. _server:
 
 -  **server** [ ``http://`` | ``https://`` |  ] <*hostname* | *ip*> [ ``:`` <*port*> ]
-   An array of Elasticsearch servers in the specified format. If no scheme is specified, 
-   it will be chosen according to usehttps_. If no port is specified, 
-   serverport_ will be used. Defaults to "localhost". 
+   An array of Elasticsearch servers in the specified format. If no scheme is specified,
+   it will be chosen according to usehttps_. If no port is specified,
+   serverport_ will be used. Defaults to "localhost".
 
    Requests to Elasticsearch will be load-balanced between all servers in round-robin fashion.
 
 ::
-  
+
   Examples:
        server="localhost:9200"
        server=["elasticsearch1", "elasticsearch2"]
@@ -33,14 +35,14 @@ Action Parameters
 .. _serverport:
 
 -  **serverport**
-   Default HTTP port to use to connect to Elasticsearch if none is specified 
+   Default HTTP port to use to connect to Elasticsearch if none is specified
    on a server_. Defaults to 9200
 
 .. _healthchecktimeout:
 
 -  **healthchecktimeout**
-   Specifies the number of milliseconds to wait for a successful health check on a server_. 
-   Before trying to submit events to Elasticsearch, rsyslog will execute an *HTTP HEAD* to 
+   Specifies the number of milliseconds to wait for a successful health check on a server_.
+   Before trying to submit events to Elasticsearch, rsyslog will execute an *HTTP HEAD* to
    ``/_cat/health`` and expect an *HTTP OK* within this timeframe. Defaults to 3500.
 
    *Note, the health check is verifying connectivity only, not the state of the Elasticsearch cluster.*
@@ -83,8 +85,8 @@ Action Parameters
 .. _pipelineName:
 
 -  **pipelineName**
-   The `ingest node <https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html>`_ 
-   pipeline name to be inclued in the request. This allows pre processing 
+   The `ingest node <https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html>`_
+   pipeline name to be inclued in the request. This allows pre processing
    of events bevor indexing them. By default, events are not send to a pipeline.
 
 .. _dynPipelineName:
@@ -151,7 +153,7 @@ readability):
    Set it to "on" and it will use Elasticsearch's `Bulk
    API <http://www.elasticsearch.org/guide/reference/api/bulk.html>`_ to
    send multiple logs in the same request. The maximum number of logs
-   sent in a single bulk request depends on your maxbytes_  
+   sent in a single bulk request depends on your maxbytes_
    and queue settings -
    usually limited by the `dequeue batch
    size <http://www.rsyslog.com/doc/node35.html>`_. More information
@@ -162,13 +164,13 @@ readability):
 
 -  **maxbytes** *(since v8.23.0)*
    When shipping logs with bulkmode_ **on**, maxbytes specifies the maximum
-   size of the request body sent to Elasticsearch. Logs are batched until 
+   size of the request body sent to Elasticsearch. Logs are batched until
    either the buffer reaches maxbytes or the the `dequeue batch
    size <http://www.rsyslog.com/doc/node35.html>`_ is reached. In order to
    ensure Elasticsearch does not reject requests due to content length, verify
-   this value is set accoring to the `http.max_content_length 
+   this value is set accoring to the `http.max_content_length
    <https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html>`_
-   setting in Elasticsearch. Defaults to 100m. 
+   setting in Elasticsearch. Defaults to 100m.
 
 .. _parent:
 

--- a/source/configuration/modules/omfile.rst
+++ b/source/configuration/modules/omfile.rst
@@ -21,9 +21,11 @@ specify module parameters, use
 
    module(load="builtin:omfile" ...parameters...)
 
-Note that legacy directives **do not** affect new-style RainerScript configuration
+Note that legacy parameters **do not** affect new-style RainerScript configuration
 objects. See :doc:`basic configuration structure doc <../basic_structure>` to
 learn about different configuration languages in use by rsyslog.
+
+Note: parameter names are case-insensitive.
 
 General Notes
 ^^^^^^^^^^^^^
@@ -38,6 +40,8 @@ is fine.
 
 Module Parameters
 ^^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
 
 .. function::  template [templateName]
 
@@ -469,7 +473,7 @@ The following properties are maintained for each dynafile:
    to inactivity. Note that if no "closeTimeout" is specified for the action,
    this counter always is zero. A high or low number in itself doesn’t mean
    anything good or bad. It totally depends on the use case, so no general
-   advise can be given. 
+   advise can be given.
 
 Caveats/Known Bugs
 ------------------
@@ -507,8 +511,10 @@ The following command writes all syslog messages into a file.
   action(type="omfile" dirCreateMode="0700" FileCreateMode="0644"
          File="/var/log/messages")
 
-Legacy Configuration Directives
+Legacy Configuration Parameters
 -------------------------------
+
+Note: parameter names are case-insensitive.
 
 Note that the legacy configuration parameters do **not** affect
 new-style action definitions via the action() object. This is
@@ -522,8 +528,8 @@ in the
 object.
 
 Read about :ref:`the importance of order in legacy configuration<legacy-action-order>`
-to understand how to use these configuration directives.
-**Legacy directives should NOT be used when writing new configuration files.**
+to understand how to use these configuration parameters.
+**Legacy parameters should NOT be used when writing new configuration files.**
 
 -  **$DynaFileCacheSize**
    equivalent to the "dynaFileCacheSize" parameter

--- a/source/configuration/modules/omfwd.rst
+++ b/source/configuration/modules/omfwd.rst
@@ -21,6 +21,8 @@ documentation <http://www.rsyslog.com/how-to-obtain-a-specific-doc-version/>`_.
 Module Parameters
 -----------------
 
+Note: parameter names are case-insensitive.
+
 -  **Template** [templateName]
 
    sets a non-standard default template for this module.
@@ -28,6 +30,8 @@ Module Parameters
 
 Action Parameters
 -----------------
+
+Note: parameter names are case-insensitive.
 
 -  **Target** string
 
@@ -220,13 +224,13 @@ Action Parameters
 -  **StreamDriverAuthMode** string
 
    authentication mode to use with the stream driver. Note that this
-   directive requires TLS netstream drivers. For all others, it will be
+   parameter requires TLS netstream drivers. For all others, it will be
    ignored. (driver-specific).
 
 -  **StreamDriverPermittedPeers** string
 
    accepted fingerprint (SHA1) or name of remote peer. Note that this
-   directive requires TLS netstream drivers. For all others, it will be
+   parameter requires TLS netstream drivers. For all others, it will be
    ignored. (driver-specific)
 
 -  **ResendLastMSGOnReconnect** on/off
@@ -293,7 +297,7 @@ Action Parameters
    defaults. If this parameter is NULL, the default settings are used. More
    information about priority Strings
    `here <https://gnutls.org/manual/html_node/Priority-Strings.html>`_.
- 
+
 See Also
 --------
 
@@ -325,15 +329,17 @@ syslogs to remote servers in different namespaces specify them as separate actio
   action(type="omfwd" Target="192.168.2.24" Port="10514" Protocol="tcp" NetworkNamespace="ns_eth0.1")
   action(type="omfwd" Target="192.168.3.38" Port="10514" Protocol="tcp" NetworkNamespace="ns_eth0.2")
 
-Legacy Configuration Directives
+Legacy Configuration Parameters
 -------------------------------
+
+Note: parameter names are case-insensitive.
 
 -  **$ActionForwardDefaultTemplateName**\ string [templatename]
    sets a new default template for UDP and plain TCP forwarding action
 -  **$ActionSendTCPRebindInterval**\ integer
    instructs the TCP send action to close and re-open the connection to
    the remote host every nbr of messages sent. Zero, the default, means
-   that no such processing is done. This directive is useful for use
+   that no such processing is done. This parameter is useful for use
    with load-balancers. Note that there is some performance overhead
    associated with it, so it is advisable to not too often "rebind" the
    connection (what "too often" actually means depends on your
@@ -342,18 +348,18 @@ Legacy Configuration Directives
 -  **$ActionSendUDPRebindInterval**\ integer
    instructs the UDP send action to rebind the send socket every nbr of
    messages sent. Zero, the default, means that no rebind is done. This
-   directive is useful for use with load-balancers.
+   parameter is useful for use with load-balancers.
 -  **$ActionSendStreamDriver**\ <driver basename>
    just like $DefaultNetstreamDriver, but for the specific action
 -  **$ActionSendStreamDriverMode**\ <mode> [default 0]
    mode to use with the stream driver (driver-specific)
 -  **$ActionSendStreamDriverAuthMode**\ <mode>
    authentication mode to use with the stream driver. Note that this
-   directive requires TLS netstream drivers. For all others, it will be
+   parameter requires TLS netstream drivers. For all others, it will be
    ignored. (driver-specific))
 -  **$ActionSendStreamDriverPermittedPeers**\ <ID>
    accepted fingerprint (SHA1) or name of remote peer. Note that this
-   directive requires TLS netstream drivers. For all others, it will be
+   parameter requires TLS netstream drivers. For all others, it will be
    ignored. (driver-specific)
 -  **$ActionSendResendLastMsgOnReconnect**\ on/off [default off]
    specifies if the last message is to be resend when a connecition
@@ -363,7 +369,7 @@ Legacy Configuration Directives
    Resets all configuration variables to their default value. Any
    settings made will not be applied to configuration lines following
    the $ResetConfigVariables. This is a good method to make sure no
-   side-effects exists from previous directives. This directive has no
+   side-effects exists from previous directives. This parameter has no
    parameters.
 
 Legacy Sample

--- a/source/configuration/modules/omhdfs.rst
+++ b/source/configuration/modules/omhdfs.rst
@@ -12,7 +12,9 @@ omhdfs: Hadoop Filesystem Output Module
 This module supports writing message into files on Hadoop's HDFS file
 system.
 
-**Configuration Directives**:
+**Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **$OMHDFSFileName** [name]
     The name of the file to which the output data shall be written.
@@ -30,8 +32,8 @@ system.
 Building omhdfs is a challenge because we could not yet find out how to
 integrate Java properly into the autotools build process. The issue is
 that HDFS is written in Java and libhdfs uses JNI to talk to it. That
-requires that various system-specific environment options and pathes be
-set correctly. At this point, we leave this to the user. If someone know
+requires that various system-specific environment options and paths be
+set correctly. At this point, we leave this to the user. If someone knows
 how to do it better, please drop us a line!
 
 -  In order to build, you need to set these environment variables BEFORE

--- a/source/configuration/modules/omhiredis.rst
+++ b/source/configuration/modules/omhiredis.rst
@@ -7,30 +7,32 @@ omhiredis: Redis Output Module
 
 **Description**
 
-This module provides native support for writing to Redis, 
+This module provides native support for writing to Redis,
 using the hiredis client library.
 
 **Action Parameters**
+
+Note: parameter names are case-insensitive.
 
 - **server**
   Name or address of the Redis server
 
 - **serverport**
   Port of the Redis server if the server is not listening on the default port.
-  
+
 - **serverpassword**
-  Password to support authenticated redis database server to push messages 
-  across networks and datacenters. Parameter is optional if not provided 
+  Password to support authenticated redis database server to push messages
+  across networks and datacenters. Parameter is optional if not provided
   AUTH command wont be sent to the server.
 
 - **mode**
   Mode to run the output action in: "queue" or "publish". If not supplied, the
-  original "template" mode is used. Note due to a config parsing bug in 8.13, 
+  original "template" mode is used. Note due to a config parsing bug in 8.13,
   explicitly setting this to "template" mode will result in a config parsing
   error.
 
 - **template**
-  Template is required if using "template" mode. 
+  Template is required if using "template" mode.
 
 - **key**
   Key is required if using "publish" or "queue" mode.
@@ -65,7 +67,7 @@ is meaningless.
 Here's an example redis-cli session where we HGETALL the counts:
 
 ::
-  > redis-cli 
+  > redis-cli
   127.0.0.1:6379> HGETALL progcount
   1) "rsyslogd"
   2) "35"
@@ -92,12 +94,12 @@ the plugin will default to the RSYSLOG_ForwardFormat template.
 Here's an example redis-cli session where we RPOP from the queue:
 
 ::
-  > redis-cli 
+  > redis-cli
   127.0.0.1:6379> RPOP my_queue
 
   "<46>2015-09-17T10:54:50.080252-04:00 myhost rsyslogd: [origin software=\"rsyslogd\" swVersion=\"8.13.0.master\" x-pid=\"6452\" x-info=\"http://www.rsyslog.com\"] start"
 
-  127.0.0.1:6379> 
+  127.0.0.1:6379>
 
 *Mode: publish*
 
@@ -119,7 +121,7 @@ will default to the RSYSLOG_ForwardFormat template.
 Here's an example redis-cli session where we SUBSCRIBE to the topic:
 
 ::
-  > redis-cli 
+  > redis-cli
 
   127.0.0.1:6379> subscribe my_channel
 

--- a/source/configuration/modules/omhttpfs.rst
+++ b/source/configuration/modules/omhttpfs.rst
@@ -22,9 +22,11 @@ This module is an alternative to omhdfs via `Hadoop HDFS over HTTP <http://hadoo
 
 Legacy config **NOT** supported.
 
+Note: parameter names are case-insensitive.
+
 -  **host**
     HttpFS server host. Default: *127.0.0.1*
-   
+
 -  **port**
     HttpFS server port. Default: *14000*
 
@@ -38,8 +40,8 @@ Legacy config **NOT** supported.
     File to write, or a template name.
 
 -  **isdynfile** \ <on/**off**>
-    Turn this on if your **file** is a template name. 
- 
+    Turn this on if your **file** is a template name.
+
     See examples below.
 
 -  **template**

--- a/source/configuration/modules/omjournal.rst
+++ b/source/configuration/modules/omjournal.rst
@@ -11,15 +11,17 @@ This module provides native support for logging to the systemd journal.
 
 **Action Parameters**:
 
+Note: parameter names are case-insensitive.
+
 -  **template**
    Template to use when submitting messages.
 
 By default, rsyslog will use the incoming %msg% as the MESSAGE field
 of the journald entry, and include the syslog tag and priority.
 
-You can override the default formatting of the message, and include 
+You can override the default formatting of the message, and include
 custom fields with a template. Complex fields in the template
-(eg. json entries) will be added to the journal as json text. Other 
+(eg. json entries) will be added to the journal as json text. Other
 fields will be coerced to strings.
 
 Journald requires that you include a template parameter named MESSAGE.

--- a/source/configuration/modules/omkafka.rst
+++ b/source/configuration/modules/omkafka.rst
@@ -15,11 +15,17 @@ Configuration Parameters
 
 Module Parameters
 ^^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
+
 Currently none.
 
 
 Action Parameters
 ^^^^^^^^^^^^^^^^^
+
+Note: parameter names are case-insensitive.
+
 Note that omkafka supports some *Array*-type parameters. While the parameter
 name can only be set once, it is possible to set multiple values with that
 single parameter.
@@ -115,7 +121,7 @@ comma-delimited list of values as shown here:
    for this action.
 
 .. function::  errorFile [filename]
-   
+
    *Default: none*
 
    If set, messages that could not be sent and caused an error
@@ -175,7 +181,7 @@ comma-delimited list of values as shown here:
 
    *Available since: 8.28.0*
 
-   If enabled, failed messages will be resubmit automatically when kafka is able to send 
+   If enabled, failed messages will be resubmit automatically when kafka is able to send
    messages again. To prevent message loss, this option should be enabled.
 
 .. function::  keepFailedMessages [boolean]
@@ -184,9 +190,9 @@ comma-delimited list of values as shown here:
 
    *Available since: 8.28.0*
 
-   If enabled, failed messages will be saved and loaded on shutdown/startup and resend after startup if 
+   If enabled, failed messages will be saved and loaded on shutdown/startup and resend after startup if
    the kafka server is able to receive messages again. This setting requires resubmitOnFailure to be enabled as well.
-   
+
 .. function::  failedMsgFile [filename]
 
    *Default: none*

--- a/source/configuration/modules/omlibdbi.rst
+++ b/source/configuration/modules/omlibdbi.rst
@@ -53,15 +53,17 @@ plugin (as omlibdbi is). So in short, you probably save you a lot of
 headache if you make sure you have at least libdbi version 0.8.3 on your
 system.
 
-**Configuration Directives**:
+**Configuration Parameters**:
+
+Note: configuration parameter names are case-insensitive.
 
 -  **$ActionLibdbiDriverDirectory** /path/to/dbd/drivers
 
    This is a global setting. It points libdbi to its driver directory.
    Usually, you do not need to set it. If you installed libdbi-driver's
    at a non-standard location, you may need to specify the directory
-   here. If you are unsure, do not use this configuration directive.
-   Usually, everything works just fine.\ 
+   here. If you are unsure, do not use this configuration parameter.
+   Usually, everything works just fine.\
 -  **$ActionLibdbiDriver** drivername
 
    Name of the dbidriver to use, see libdbi-drivers documentation. As a

--- a/source/configuration/modules/ommail.rst
+++ b/source/configuration/modules/ommail.rst
@@ -1,7 +1,7 @@
 ommail: Mail Output Module
 ==========================
 
-.. index:: ! imudp 
+.. index:: ! imudp
 
 
 ===========================  ===========================================================================
@@ -37,7 +37,7 @@ parameter to limit the amount of mails that potentially be
 generated. With it, mails are sent at most in a <seconds> interval. This
 may be your life safer. And remember that an hour has 3,600 seconds, so
 if you would like to receive mails at most once every two hours, include
-a 
+a
 
 ::
 
@@ -49,6 +49,8 @@ Configuration Parameters
 ------------------------
 Configuration parameters are supported starting with v8.5.0. Earlier
 v7 and v8 versions did only support legacy parameters.
+
+Note: parameter names are case-insensitive.
 
 Action Parameters
 ^^^^^^^^^^^^^^^^^
@@ -214,7 +216,7 @@ constant subject line, so no subject template is required:
 	     action.execonlyonceeveryinterval="21600")
   }
 
-Legacy Configuration Directives
+Legacy Configuration Parameters
 -------------------------------
 
 Note that the legacy configuration parameters do **not** affect
@@ -229,8 +231,8 @@ in the
 object.
 
 Read about :ref:`the importance of order in legacy configuration<legacy-action-order>`
-to understand how to use these configuration directives.
-**Legacy directives should NOT be used when writing new configuration files.**
+to understand how to use these configuration parameters.
+**Legacy parameters should NOT be used when writing new configuration files.**
 
 
 -  $ActionMailSMTPServer

--- a/source/configuration/modules/ommongodb.rst
+++ b/source/configuration/modules/ommongodb.rst
@@ -11,6 +11,8 @@ This module provides native support for logging to MongoDB.
 
 **Action Parameters**:
 
+Note: parameter names are case-insensitive.
+
 -  **uristr**
    MongoDB connexion string, as defined by the MongoDB String URI Format (See: https://docs.mongodb.com/manual/reference/connection-string/). If uristr is defined, following directives will be ignored: server, serverport, uid, pwd.
 -  **ssl_cert**
@@ -82,10 +84,10 @@ Another sample that uses the new "uristr" directives to connect to a TLS mongoDB
 ::
 
    module(load="ommongodb")
-   action(type="ommongodb" 
-         uristr="mongodb://vulture:9091,vulture2:9091/?replicaset=Vulture&ssl=true" 
-         ssl_cert="/var/db/mongodb/mongod.pem" 
-         ssl_ca="/var/db/mongodb/ca.pem" 
+   action(type="ommongodb"
+         uristr="mongodb://vulture:9091,vulture2:9091/?replicaset=Vulture&ssl=true"
+         ssl_cert="/var/db/mongodb/mongod.pem"
+         ssl_ca="/var/db/mongodb/ca.pem"
          db="logs" collection="syslog")
 
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_

--- a/source/configuration/modules/ommysql.rst
+++ b/source/configuration/modules/ommysql.rst
@@ -12,32 +12,34 @@ This module provides native support for logging to MySQL databases. It
 offers superior performance over the more generic
 `omlibdbi <omlibdbi.html>`_ module.
 
-**Configuration Directives**:
+**Configuration parameters**:
+
+Note: configuration parameter names are case-insensitive.
 
 ommysql mostly uses the "old style" configuration, with almost
 everything on the action line itself. A few newer features are being
-migrated to the new style-config directive configuration system.
+migrated to the new style-config parameter configuration system.
 
 -  **$ActionOmmysqlServerPort <port>**
 
    Permits to select a non-standard port for the MySQL server. The
    default is 0, which means the system default port is used. There is
-   no need to specify this directive unless you know the server is
+   no need to specify this parameter unless you know the server is
    running on a non-standard listen port.
 -  **$OmMySQLConfigFile <file name>**
 
    Permits the selection of an optional MySQL Client Library
    configuration file (my.cnf) for extended configuration functionality.
-   The use of this configuration directive is necessary only if you have
+   The use of this configuration parameter is necessary only if you have
    a non-standard environment or if fine-grained control over the
    database connection is desired.
 -  **$OmMySQLConfigSection <string>**
 
    Permits the selection of the section within the configuration file
-   specified by the **$OmMySQLConfigFile** directive.
+   specified by the **$OmMySQLConfigFile** parameter.
    This will likely only be used where the database administrator
    provides a single configuration file with multiple profiles.
-   This configuration directive is ignored unless **$OmMySQLConfigFile**
+   This configuration parameter is ignored unless **$OmMySQLConfigFile**
    is also used in the rsyslog configration file.
    If omitted, the MySQL Client Library default of "client" will be
    used.

--- a/source/configuration/modules/ompgsql.rst
+++ b/source/configuration/modules/ompgsql.rst
@@ -18,6 +18,8 @@ This module provides native support for logging to PostgreSQL databases. It's an
 Input parameters
 ****************
 
+Note: configuration parameter names are case-insensitive.
+
 -  **server** - default: none, required: true
 
    The hostname or address of the PostgreSQL server.
@@ -113,6 +115,8 @@ Legacy
 
 **Action parameters**
 
+Note: parameter names are case-insensitive.
+
 **:ompgsql:database-server,database-name,database-userid,database-password**
 
 All parameters should be filled in for a successful connect.
@@ -146,4 +150,3 @@ Copyright © 2008-2014 by `Rainer
 Gerhards <http://www.gerhards.net/rainer>`_ and
 `Adiscon <http://www.adiscon.com/>`_. Released under the GNU GPL version
 3 or higher.
-

--- a/source/configuration/modules/ompipe.rst
+++ b/source/configuration/modules/ompipe.rst
@@ -8,13 +8,18 @@ ompipe: Pipe Output Module
 **Description**:
 
 The ompipe plug-in provides the core functionality for logging output to named pipes (fifos). It is a built-in module that does not need to be loaded.
-**Global Configuration Directives:**
+
+**Global Configuration Parameters:**
+
+Note: parameter names are case-insensitive.
 
 -  Template: [templateName] sets a new default template for file actions.
 
-**Action specific Configuration Directives:**
+**Action specific Configuration Parameters:**
 
--  Pipe: string a fifo or named pipe can be used as a destination for log messages. 
+Note: parameter names are case-insensitive.
+
+-  Pipe: string a fifo or named pipe can be used as a destination for log messages.
 
 **Caveats/Known Bugs:**
 None
@@ -24,12 +29,12 @@ The following command sends all syslog messages to a remote server via TCP port 
 
 ::
 
-        Module (path="builtin:ompipe") 
+        Module (path="builtin:ompipe")
         *.* action(type="ompipe" Pipe="NameofPipe")
-    
-**Legacy Configuration Directives:**
 
-rsyslog has support for logging output to named pipes (fifos). A fifo or named pipe can be used as a destination for log messages by prepending a pipe symbol ("|") to the name of the file. This is handy for debugging. Note that the fifo must be created with the mkfifo(1) command before rsyslogd is started. 
+**Legacy Configuration Parameters:**
+
+rsyslog has support for logging output to named pipes (fifos). A fifo or named pipe can be used as a destination for log messages by prepending a pipe symbol ("|") to the name of the file. This is handy for debugging. Note that the fifo must be created with the mkfifo(1) command before rsyslogd is started.
 
 **Legacy Sample:**
 
@@ -37,9 +42,9 @@ The following command sends all syslog messages to a remote server via TCP port 
 
 ::
 
-        $ModLoad ompipe 
-        *.* |/var/log/pipe 
-    
+        $ModLoad ompipe
+        *.* |/var/log/pipe
+
 This documentation is part of the `rsyslog <http://www.rsyslog.com/>`_
 project.
 Copyright © 2008-2014 by `Rainer

--- a/source/configuration/modules/omprog.rst
+++ b/source/configuration/modules/omprog.rst
@@ -46,7 +46,7 @@ when we execute a binary, we need to fork, and we do not have
 full access to rsyslog's usual error-reporting capabilities after the
 fork. As the actual execution must happen after the fork, we cannot
 use the default error logger to emit the error message. As such,
-we use ``syslog()``. In most cases, there is no real difference 
+we use ``syslog()``. In most cases, there is no real difference
 between both methods. However, if you run multiple rsyslog instances,
 the messae shows up in that instance that processes the default
 log socket, which may be different from the one where the error occured.
@@ -56,12 +56,16 @@ not work as expected.
 
 **Module Parameters**:
 
+Note: parameter names are case-insensitive.
+
 -  **Template**\ [templateName]
     sets a new default template for file actions.
 
  
 
 **Action Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **binary**
    Mostly equivalent to the "binary" action parameter, but must contain

--- a/source/configuration/modules/omrelp.rst
+++ b/source/configuration/modules/omrelp.rst
@@ -1,4 +1,4 @@
-omrelp: RELP Output Module 
+omrelp: RELP Output Module
 ==========================
 
 **Module Name:    omrelp**
@@ -21,6 +21,8 @@ imrelp (it provides the core relp protocol implementation).
 This module supports RainerScript configuration starting with rsyslog
 7.3.10. For older versions, legacy configuration directives must be
 used.
+
+Note: parameter names are case-insensitive.
 
 -  **target** (mandatory)
    The target server to connect to.
@@ -85,7 +87,7 @@ used.
    this:
 
    ::
-   
+
      tls.permittedPeer=["SHA1:...1", "SHA1:....2"]
 
    To specify just a single peer, you can either specify the string

--- a/source/configuration/modules/omruleset.rst
+++ b/source/configuration/modules/omruleset.rst
@@ -60,7 +60,9 @@ before using omruleset!**
 -  if you use multiple levels of ruleset nesting, double check for
    endless loops - the rsyslog engine does not detect these
 
-**Configuration Directives**:
+**Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **$ActionOmrulesetRulesetName** ruleset-to-submit-to
    This directive specifies the name of the ruleset that the message
@@ -131,7 +133,7 @@ one.
   mail.* /path/to/mailerr.log
   kernel.* /path/to/kernelerr.log
   auth.* /path/to/autherr.log
-  
+
   #switch back to default ruleset
   $ruleset RSYSLOG_DefaultRuleset
 
@@ -140,7 +142,7 @@ one.
   $ActionOmrulesetRulesetName nested
   :msg, contains, "error" :omruleset:
   #end first action
-  
+
   # begin second action - as an example we can do anything else in
   # this processing. Note that these actions are processed concurrently
   # to the ruleset "nested"

--- a/source/configuration/modules/omsnmp.rst
+++ b/source/configuration/modules/omsnmp.rst
@@ -23,7 +23,9 @@ package installed.
 
  
 
-**Configuration Directives**:
+**Configuration parameters**:
+
+Note: configuration parameter names are case-insensitive.
 
 -  **$actionsnmptransport**\ (This parameter is optional, the default
    value is "udp")
@@ -34,8 +36,8 @@ package installed.
    udp, tcp, udp6, tcp6, icmp, icmp6 ...
 
    Example: ``$actionsnmptransport udp``
- 
- 
+
+
 -  **$actionsnmptarget**
 
    This can be a hostname or ip address, and is our snmp target host.
@@ -43,16 +45,16 @@ package installed.
    will be send.
 
    Example: ``$actionsnmptarget server.domain.xxx``
- 
- 
+
+
 -  **$actionsnmptargetport** (This parameter is optional, the default
    value is "162")
 
    The port which will be used, common values are port 162 or 161.
 
    Example: ``$actionsnmptargetport 162``
- 
- 
+
+
 -  **$actionsnmpversion** (This parameter is optional, the default
    value is "1")
 
@@ -60,18 +62,18 @@ package installed.
    0 means SNMPv1 will be used.
    1 means SNMPv2c will be used.
    Any other value will default to 1.
-   
+
    Example: ``$actionsnmpversion 1``
- 
- 
+
+
 -  **$actionsnmpcommunity** (This parameter is optional, the default
    value is "public")
 
    This sets the used SNMP Community.
 
    Example: ``$actionsnmpcommunity public``
- 
- 
+
+
 -  **$actionsnmptrapoid** (This parameter is optional, the default
    value is "1.3.6.1.4.1.19406.1.2.1" which means
    "ADISCON-MONITORWARE-MIB::syslogtrap")
@@ -92,8 +94,8 @@ package installed.
    Example: ``$actionsnmptrapoid 1.3.6.1.4.1.19406.1.2.1``
    If you have this MIBS installed, you can also configured with the
    OID Name: ``$actionsnmptrapoid ADISCON-MONITORWARE-MIB::syslogtrap``
- 
- 
+
+
 -  **$actionsnmpsyslogmessageoid** (This parameter is optional, the
    default value is "1.3.6.1.4.1.19406.1.1.2.1" which means
    "ADISCON-MONITORWARE-MIB::syslogMsg")
@@ -111,8 +113,8 @@ package installed.
    If you have this MIBS installed, you can also configured with the
    OID Name: ``$actionsnmpsyslogmessageoid``
    ADISCON-MONITORWARE-MIB::syslogMsg
- 
- 
+
+
 -  **$actionsnmpenterpriseoid** (This parameter is optional, the
    default value is "1.3.6.1.4.1.3.1.1" which means
    "enterprises.cmu.1.1")
@@ -123,8 +125,8 @@ package installed.
    effect if **SNMPv2** is used.
 
    Example: ``$actionsnmpenterpriseoid 1.3.6.1.4.1.3.1.1``
- 
- 
+
+
 -  **$actionsnmpspecifictype** (This parameter is optional, the default
    value is "0")
 
@@ -132,8 +134,8 @@ package installed.
    used for **SNMPv1** only. It has no effect if **SNMPv2** is used.
 
    Example: ``$actionsnmpspecifictype 0``
- 
- 
+
+
 -  **$actionsnmptraptype** (This parameter is optional, the default
    value is "6" which means SNMP\_TRAP\_ENTERPRISESPECIFIC)
 

--- a/source/configuration/modules/omstdout.rst
+++ b/source/configuration/modules/omstdout.rst
@@ -16,7 +16,9 @@ the quality of this module as we do not expect it to be used in real
 deployments. If you do, please drop us a note so that we can enhance
 its priority!
 
-**Configuration Directives**:
+**Configuration parameters**:
+
+Note: configuration directive names are case-insensitive.
 
 -  **$ActionOMStdoutArrayInterface** [on\|**off**
    This setting instructs omstdout to use the alternate array based

--- a/source/configuration/modules/omudpspoof.rst
+++ b/source/configuration/modules/omudpspoof.rst
@@ -17,6 +17,8 @@ source ports.
 Module Parameters
 -----------------
 
+Note: parameter names are case-insensitive.
+
 -  **template** <templatename>
 
    This setting instructs omudpspoof to use a template different from
@@ -25,6 +27,8 @@ Module Parameters
 
 Action Parameters
 -----------------
+
+Note: parameter names are case-insensitive.
 
 -  **target** <hostname> or <ip>
 

--- a/source/configuration/modules/omusrmsg.rst
+++ b/source/configuration/modules/omusrmsg.rst
@@ -13,10 +13,14 @@ This module permits to send log messages to the user terminal.
 
 **Module Parameters**:
 
+Note: parameter names are case-insensitive.
+
 none
  
 
 **Action Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **users**
    the name of the users to send data to.

--- a/source/configuration/modules/omuxsock.rst
+++ b/source/configuration/modules/omuxsock.rst
@@ -15,7 +15,9 @@ instances. The counterpart to omuxsock is `imuxsock <imuxsock.html>`_.
 Note that the template used together with omuxsock must be suitable to
 be processed by the receiver.
 
-**Configuration Directives**:
+**Configuration Parameters**:
+
+Note: parameter names are case-insensitive.
 
 -  **$OMUxSockSocket**
    Name of the socket to send data to. This has no default and **must**
@@ -35,7 +37,7 @@ The following sample writes all messages to the "/tmp/socksample"
 socket.
 
 ::
-  
+
   $ModLoad omuxsock
   $OMUxSockSocket /tmp/socksample
   *.* :omuxsock:

--- a/source/configuration/modules/pmciscoios.rst
+++ b/source/configuration/modules/pmciscoios.rst
@@ -30,6 +30,8 @@ dots (.) are ignored. This may lead to "incorrect" timestamps being logged.
 Parser Parameters
 -----------------
 
+Note: parameter names are case-insensitive.
+
 .. function::  present.origin <boolean>
 
    **Default**: off
@@ -40,7 +42,7 @@ Parser Parameters
    or not (at least not with reasonable performance). As such, the parser
    must be provided with that information. If the origin is present,
    its value is stored inside the HOSTNAME message property.
-   
+
    .. function::  present.xr <boolean>
 
    **Default**: off
@@ -132,7 +134,7 @@ The following sample demonstrates how to handle Cisco IOS and IOSXR formats
    ruleset(name="ios" parser="rsyslog.ciscoios") {
        call common
    }
-   
+
    parser(name="custom.ciscoios.withXr" type="pmciscoios"
           present.xr="on")
    ruleset(name="iosxr" parser="custom.ciscoios.withXr"] {

--- a/source/configuration/modules/pmlastmsg.rst
+++ b/source/configuration/modules/pmlastmsg.rst
@@ -29,9 +29,11 @@ contain a PRI, then none or some spaces and then the exact text
 (case-insensitive) "last message repeated n times" where n must be an
 integer. All other messages are left untouched.
 
-**Configuration Directives**:
+**Configuration Parameters**:
 
-There do not currently exist any configuration directives for this
+Note: parameter names are case-insensitive.
+
+There do not currently exist any configuration parameters for this
 module.
 
 **Examples:**

--- a/source/configuration/modules/pmnormalize.rst
+++ b/source/configuration/modules/pmnormalize.rst
@@ -15,6 +15,8 @@ properties for further use.
 Action Parameters
 ~~~~~~~~~~~~~~~~~
 
+Note: parameter names are case-insensitive.
+
 .. function:: rulebase <word>
 
    Specifies which rulebase file is to use. If there are multiple

--- a/source/configuration/modules/pmnull.rst
+++ b/source/configuration/modules/pmnull.rst
@@ -11,6 +11,8 @@ process certain known-not-syslog messages.
 Parser Parameters
 -----------------
 
+Note: parameter names are case-insensitive.
+
 .. function:: tag <string>
 
    **Default**: Empty ("")

--- a/source/configuration/modules/pmrfc3164.rst
+++ b/source/configuration/modules/pmrfc3164.rst
@@ -3,16 +3,18 @@ pmrfc3164: Parse RFC3164-formatted messages
 
 Author: Rainer Gerhards
 
-This parser module is for parsing messages according to the traditional/legacy 
+This parser module is for parsing messages according to the traditional/legacy
 syslog standard :rfc:`3164`
 
 It is part of the default parser chain.
 
-The parser can also be customized to allow the parsing of specific formats, 
+The parser can also be customized to allow the parsing of specific formats,
 if they occur.
 
 Parser Parameters
 -----------------
+
+Note: parameter names are case-insensitive.
 
 .. function:: permit.squareBracketsInHostname <boolean>
 
@@ -67,27 +69,27 @@ Parser Parameters
 
    **Default**: off
 
-   Some devices send syslog messages in a format that is similar to RFC3164, 
+   Some devices send syslog messages in a format that is similar to RFC3164,
    but they also attach the year to the timestamp (which is not compliant to
-   the RFC). With regular parsing, the year would be recognized to be the 
-   hostname and the hostname would become the syslogtag. This setting should 
-   prevent this. It is also limited to years between 2000 and 2099, so 
+   the RFC). With regular parsing, the year would be recognized to be the
+   hostname and the hostname would become the syslogtag. This setting should
+   prevent this. It is also limited to years between 2000 and 2099, so
    hostnames with numbers as their name can still be recognized correctly. But
    everything in this range will be detected as a year.
-   
+
 Example
 -------
 We assume a scenario where some of the devices send malformed RFC3164
 messages. The parser module will automatically detect the malformed
-sections and parse them accordingly. 
+sections and parse them accordingly.
 
 ::
 
    module(load="imtcp")
-   
+
    input(type="imtcp" port="514" ruleset="customparser")
 
-   parser(name="custom.rfc3164" 
+   parser(name="custom.rfc3164"
    	 type="pmrfc3164"
    	 permit.squareBracketsInHostname="on"
    	 detect.YearAfterTimestamp="on")

--- a/source/configuration/modules/sigprov_gt.rst
+++ b/source/configuration/modules/sigprov_gt.rst
@@ -14,6 +14,8 @@ services.
 
 **Configuration Parameters**:
 
+Note: parameter names are case-insensitive.
+
 Signature providers are loaded by omfile, when the provider is selected
 in its "sig.providerName" parameter. Parameters for the provider are
 given in the omfile action instance line.

--- a/source/configuration/modules/sigprov_ksi.rst
+++ b/source/configuration/modules/sigprov_ksi.rst
@@ -14,6 +14,8 @@ signature services.
 
 **Configuration Parameters**:
 
+Note: parameter names are case-insensitive.
+
 Signature providers are loaded by omfile, when the provider is selected
 in its "sig.providerName" parameter. Parameters for the provider are
 given in the omfile action instance line.

--- a/source/configuration/modules/sigprov_ksi12.rst
+++ b/source/configuration/modules/sigprov_ksi12.rst
@@ -45,6 +45,8 @@ Currently the log signing is only supported by the file output module, thus the 
 
 Mandatory parameters (no default value defined):
 
+Note: parameter names are case-insensitive.
+
 - **sig.provider** specifies the signature provider; in case of ``rsyslog-ksi-ls12`` package this is ``"ksi_ls12"``.
 - **sig.block.levelLimit** defines the maximum level of the root of the local aggregation tree per one block.
 - **sig.aggregator.url** defines the endpoint of the KSI signing service in KSI Gateway. Supported URI schemes are:
@@ -57,6 +59,8 @@ Mandatory parameters (no default value defined):
 - **sig.aggregator.key** specifies the key for the login name.
 
 Optional parameters (if not defined, default value is used):
+
+Note: parameter names are case-insensitive.
 
 - **sig.syncmode** defines the signing mode: ``"sync"`` (default) or ``"async"``.
 - **sig.hashFunction** defines the hash function to be used for hashing, default is ``"SHA2-256"``.

--- a/source/configuration/parser.rst
+++ b/source/configuration/parser.rst
@@ -1,7 +1,7 @@
 Parser
 ======
 
-.. index:: ! parser 
+.. index:: ! parser
 .. _cfgobj_input:
 
 The ``parser`` object, as its name suggests, describes message parsers.
@@ -17,7 +17,7 @@ be defined using the parser() object. A parser name defined via the
 parser() object can be used whereever a parser name can occur.
 
 Note that not all message parser modules are supported in the parser()
-object. The reason is that many do not have any user-selectable 
+object. The reason is that many do not have any user-selectable
 parameters and as such, there is no point in issuing a parser() object
 for them.
 
@@ -32,6 +32,8 @@ The parser object has different parameters:
 
 General Parser Parameters
 -------------------------
+
+Note: parameter names are case-insensitive.
 
 .. function::  name <name-string>
 
@@ -49,7 +51,7 @@ General Parser Parameters
    The ``<type-string>`` is a string identifying the parser module as given
    it each module's documentation. Do not mistake the parser module name
    with its default parser name.
-   For example, the 
+   For example, the
    :doc:`Cisco IOS message parser module <modules/pmciscoios>` parser module
    name is "pmciscoios", whereas it's default parser name is
    "rsyslog.pmciscoios".
@@ -73,7 +75,7 @@ The following example uses multiple parsers within a ruleset without a parser ob
 
   module(load="pmaixforwardedfrom")
   module(load="pmlastmsg")
-  
+
   ruleset(name="myRuleset" parser=["rsyslog.lastline","rsyslog.aixforwardedfrom","rsyslog.rfc5424","rsyslog.rfc3164"]) {
      ... do something here ...
   }

--- a/source/configuration/timezone.rst
+++ b/source/configuration/timezone.rst
@@ -1,7 +1,7 @@
 timezone
 ========
 
-.. index:: ! timezone 
+.. index:: ! timezone
 .. _cfgobj_input:
 
 The ``timezone`` object, as its name suggests, describes timezones.
@@ -13,6 +13,9 @@ an UTC offset for a given timezone ID.
 Each timestamp object adds the zone definition to a global table
 with timezone information. Duplicate IDs are forbidden, but the
 same offset may be used with multiple IDs.
+
+As with other configuration objects, parameters for this
+object are case-insensitive.
 
 
 Parameters
@@ -27,7 +30,7 @@ Parameters
    use different, often non-standard, names and so it is important to use
    the actual ids that messages contain. For multiple devices, this may
    mean that you may need to include multiple definitions, each one with a
-   different id, for the same time zone. For example, it is seen that 
+   different id, for the same time zone. For example, it is seen that
    some devices report "CEST" for central European daylight savings time
    while others report "METDST" for it.
 

--- a/source/rainerscript/configuration_objects.rst
+++ b/source/rainerscript/configuration_objects.rst
@@ -1,6 +1,8 @@
 configuration objects
 =====================
 
+Note: configuration object parameters are case-insensitive.
+
 action()
 --------
 

--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -4,7 +4,8 @@ global() configuration object
 The global configuration object permits to set global parameters. Note
 that each parameter can only be set once and cannot be re-set
 thereafter. If a parameter is set multiple times, the behaviour is
-unpredictable.
+unpredictable. As with other configuration objects, parameters for this
+object are case-insensitive.
 
 The following parameters can be set:
 
@@ -51,22 +52,22 @@ The following parameters can be set:
   **This parameter only has an effect if general debugging is enabled.**
 
 - **processInternalMessages** binary (on/off)
-  
+
   This tells rsyslog if it shall process internal messages itself. The
-  default mode of operations ("off") makes rsyslog send messages to the 
-  system log sink (and if it is the only instance, receive them back from there). 
+  default mode of operations ("off") makes rsyslog send messages to the
+  system log sink (and if it is the only instance, receive them back from there).
   This also works with systemd journal and will make rsyslog messages show up in the
-  systemd status control information. 
-  
+  systemd status control information.
+
   If this (instance) of rsyslog is not the main instance and there is another
   main logging system, rsyslog internal messages will be inserted into
-  the main instance's syslog stream. In this case, setting to ("on") will 
+  the main instance's syslog stream. In this case, setting to ("on") will
   let you receive the internal messages in the instance they originate from.
-  
-  Note that earlier versions of rsyslog worked the opposite way. More 
-  information about the change can be found in `rsyslog-error-reporting-improved <http://www.rsyslog.com/rsyslog-error-reporting-improved>`_. 
-  
-  
+
+  Note that earlier versions of rsyslog worked the opposite way. More
+  information about the change can be found in `rsyslog-error-reporting-improved <http://www.rsyslog.com/rsyslog-error-reporting-improved>`_.
+
+
 
 - **stdlog.channelspec**
 
@@ -125,13 +126,13 @@ The following parameters can be set:
   performance reasons. If DNS fails during that process, the hostname
   is added as wildcard text, which results in proper, but somewhat
   slower operation once DNS is up again.
-  
+
   The default is "off".
 
 - **net.aclResolveHostname** available in 8.6.0+
-  
+
   If "off", do not resolve hostnames to IP addresses during ACL processing.
-  
+
   The default is "on".
 
 - **net.enableDNS** [on/off] available in 8.6.0+
@@ -139,7 +140,7 @@ The following parameters can be set:
   **Default:** on
 
   Can be used to turn DNS name resolution on or off.
-  
+
 - **net.permitACLWarning** [on/off] available in 8.6.0+
 
   **Default:** on
@@ -171,18 +172,18 @@ The following parameters can be set:
   syslogtag. In those cases, the programname is truncated at the
   first slash. If this setting is changed to "on", slashes are
   permitted and will not terminate programname parsing.
-  
+
 - **parser.permitSlashInProgramName** [on/off] available in 8.25.0+
 
   **Default:** off
 
-  This controls whether slashes in the static part of the tag are 
-  permitted or not. If this setting is off, a value of 
-  "app/foo[1234]" in the tag will result in a programname of "app". 
-  If an application stores an absolute path name like 
+  This controls whether slashes in the static part of the tag are
+  permitted or not. If this setting is off, a value of
+  "app/foo[1234]" in the tag will result in a programname of "app".
+  If an application stores an absolute path name like
   "/app/foo[1234]", the programname property will become empty ("").
   If you need to actually store slashes as part of the programname,
-  this setting should be changed to "on" to permit this. Then, a 
+  this setting should be changed to "on" to permit this. Then, a
   syslogtag of "/app/foo[1234]" will result in programname being
   "/app/foo".
 

--- a/source/rainerscript/queue_parameters.rst
+++ b/source/rainerscript/queue_parameters.rst
@@ -13,7 +13,9 @@ ruleset has only the default main queue. Specific Action queues are not
 set up by default.
 
 To fully understand queue parameters and how they interact, be sure to
-read the :doc:`queues <../concepts/queues>` documentation.
+read the :doc:`queues <../concepts/queues>` documentation. Note:
+As with other configuration objects, parameters for this
+object are case-insensitive.
 
 -  **queue.filename** name
    File name to be used for the queue files. Please note that this is
@@ -56,16 +58,16 @@ read the :doc:`queues <../concepts/queues>` documentation.
    default 90% of queue size
 -  **queue.lowwatermark** number
    default 70% of queue size
--  **queue.fulldelaymark** number 
-   Number of messages when the queue should block delayable messages. 
-   Messages are NO LONGER PROCESSED until the queue has sufficient space 
-   again. If a message is delayable depends on the input. For example, 
-   messages received via imtcp are delayable (because TCP can push back), 
+-  **queue.fulldelaymark** number
+   Number of messages when the queue should block delayable messages.
+   Messages are NO LONGER PROCESSED until the queue has sufficient space
+   again. If a message is delayable depends on the input. For example,
+   messages received via imtcp are delayable (because TCP can push back),
    but those received via imudp are not (as UDP does not permit a push back).
-   The intent behind this setting is to leave some space in an almost-full 
-   queue for non-delayable messages, which would be lost if the queue runs 
-   out of space. Please note that if you use a DA queue, setting the 
-   fulldelaymark BELOW the highwatermark makes the queue never activate 
+   The intent behind this setting is to leave some space in an almost-full
+   queue for non-delayable messages, which would be lost if the queue runs
+   out of space. Please note that if you use a DA queue, setting the
+   fulldelaymark BELOW the highwatermark makes the queue never activate
    disk mode for delayable inputs. So this is probably not what you want.
    default 97% of queue size
 -  **queue.lightdelaymark** number
@@ -75,16 +77,16 @@ read the :doc:`queues <../concepts/queues>` documentation.
 -  **queue.discardseverity** number
    \*numerical\* severity! default 8 (nothing discarded)
 -  **queue.checkpointinterval** number
-   Disk queues by default do not update housekeeping structures every time 
-   the queue writes to disk. This is for performance reasons. In the event of failure, 
+   Disk queues by default do not update housekeeping structures every time
+   the queue writes to disk. This is for performance reasons. In the event of failure,
    data will still be lost (except when data is mangled via the file structures).
-   However, disk queues can be set to write bookkeeping information on checkpoints 
-   (every n records), so that this can be made ultra-reliable, too. If the 
-   checkpoint interval is set to one, no data can be lost, but the queue is 
+   However, disk queues can be set to write bookkeeping information on checkpoints
+   (every n records), so that this can be made ultra-reliable, too. If the
+   checkpoint interval is set to one, no data can be lost, but the queue is
    exceptionally slow.
 -  **queue.syncqueuefiles** on/off (default "off")
 
-   Disk-based queues can be made very reliable by issuing a (f)sync after each 
+   Disk-based queues can be made very reliable by issuing a (f)sync after each
    write operation. This happens when you set the parameter to "on".
    Activating this option has a performance penalty, so it should not
    be turned on without a good reason. Note that the penalty also depends on


### PR DESCRIPTION
My editor "helped" by trimming whitespace, so some NOOP changes were rolled into this commit in addition to the intended changes.

It feels like overkill, but I ended up placing this statement in the majority of files I found that mentioned parameters/directives:

`Note: parameter names are case-insensitive.`

If that ends up being useful, perhaps we could use a substitution reference for it as well.

While I was making that change I tried to replace instances of "directive" with "parameter" as discussed on the linked issue.

refs rsyslog/rsyslog-doc#391