### PR TITLE
Attempt to better emphasize relationship between global maxMessageSize, imrelp's MaxDataSize parameters

### DIFF
--- a/source/configuration/modules/imrelp.rst
+++ b/source/configuration/modules/imrelp.rst
@@ -57,7 +57,7 @@ Note: parameter names are case-insensitive.
 
 .. function:: MaxDataSize <size_nbr>
 
-   *Default is the global message size*
+   *Default is value of* :doc:`global(maxMessageSize) <../../rainerscript/global>` *parameter*
 
    Sets the max message size (in bytes) that can be received. Any messages above this size
    will be rejected causing the relp client to reconnect and retry.

--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -84,8 +84,11 @@ The following parameters can be set:
 
 - **maxMessageSize**
 
-  The maximum message size rsyslog can process. Default is 8K. Anything
-  above the maximum size will be truncated.
+  Configures the maximum message size allowed for all inputs. Default is 8K.
+  Anything above the maximum size will be truncated.
+
+  Note: some modules provide separate parameters that allow overriding this
+  setting (e.g., :doc:`imrelp's MaxDataSize parameter <../../configuration/modules/imrelp>`).
 
 .. _global_janitorInterval:
 


### PR DESCRIPTION
@rgerhards Please let me know what you think.

refs rsyslog/rsyslog-doc#432