### PR TITLE
Add sphinx-build temp dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+source/_build
 .project
 .vscode
 *.pyc


### PR DESCRIPTION
Helps prevent editors (at least the ones I use) with integrated Git support from flagging temp files as changes that I should be aware of.