### PR TITLE
Fix git tag sort compatibility with Python 3.6.x

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -68,7 +68,7 @@ author = u'Rainer Gerhards and Others'
 # Generate the current stable version number from the latest git tag
 git_tag_output = subprocess.check_output(['git', 'tag', '--list', "v*"]).decode("utf-8").strip()
 git_tag_list = re.sub('[A-Za-z]', '', git_tag_output).split('\n')
-git_tag_list.sort(key=lambda s: map(int, s.split('.')))
+git_tag_list.sort(key=lambda s: [int(u) for u in s.split('.')])
 git_tag_latest = git_tag_list[-1]
 
 


### PR DESCRIPTION
Use a list comprehension in order to work equally well on Python 2 or Python 3. 

I originally tested in the recommended Python 2 build environment and had no issues. I _believe_ I also tested in a Python 3.5.x environment without problems, but tonight when attempting to build on a Windows 10 box with Python 3.6.3 I got some Python 3 specific errors:

```
TypeError: '<' not supported between instances of 'map' and 'map'
```

I found the workaround here:

https://stackoverflow.com/questions/2574080/sorting-a-list-of-dot-separated-numbers-like-software-versions