### PR TITLE
imrelp: Remove stray word

### DIFF
--- a/source/configuration/modules/imrelp.rst
+++ b/source/configuration/modules/imrelp.rst
@@ -241,7 +241,6 @@ Caveats/Known Bugs
    listeners, not specific ones. This issue is resolved in the
    non-Legacy configuration format.
 
-**Sample:**
 
 Legacy Sample
 -------------


### PR DESCRIPTION
Looks like someone may have left the word behind from a previous edit.

refs rsyslog/rsyslog-doc#109
