### PR TITLE
Add RainerScript is_time() function

### DIFF
--- a/source/rainerscript/functions.rst
+++ b/source/rainerscript/functions.rst
@@ -363,3 +363,58 @@ produces
 ::
 
    1507151411
+
+is_time(timestamp, format_str)
+---------------------------------------
+
+   Checks the given timestamp to see if it is a valid date/time string (RFC 3164,
+   or RFC 3339), or a UNIX timestamp.
+
+   This function returns ``1`` for valid date/time strings and UNIX timestamps,
+   ``0`` otherwise. Additionally, if the input cannot be parsed, or there is
+   an error, ``script_error()`` will be set to error state.
+
+   The ``format_str`` parameter is optional, and can be one of ``"date-rfc3164"``,
+   ``"date-rfc3339"`` or ``"date-unix"``. If this parameter is specified, the
+   function will only succeed if the input matches that format. If omitted, the
+   function will compare the input to all of the known formats (indicated above)
+   to see if one of them matches.
+
+   * **Note**: This function does not support unusual RFC 3164 dates/times that
+     contain year or time zone information.
+
+::
+
+   is_time("Oct  5 01:10:11")
+   is_time("2017-10-05T01:10:11+04:00")
+   is_time(1507165811)
+
+all produce
+
+::
+
+   1
+
+and
+
+::
+
+   is_time("2017-10-05T01:10:11+04:00", "date-rfc3339")
+
+produces
+
+::
+
+   1
+
+and
+
+::
+
+   is_time("2017-10-05T01:10:11+04:00", "date-unix")
+
+produces
+
+::
+
+   0


### PR DESCRIPTION
Adds documentation for the `is_time()` function.

See rsyslog/rsyslog#2246 and rsyslog/rsyslog#1624.