### PR TITLE
build.sh: Fix typos, block accidental commits

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,67 +6,34 @@ set -u
 # Exit if any statement returns a non-true value
 set -e
 
-echo ""
-echo "This script is intended to run with the clean repo version of the code."
-echo "Run the sphinx-build command manually if you want to see your uncommited changes."
-echo "If you run this script with uncommitted and un-pushed changes, YOU WILL LOSE THOSE CHANGES!"
-echo ""
-echo "Press Enter to continue or Ctrl-C to cancel...."
-read -r REPLY
-
-
-###############################################################
-# Refresh local content (needs to run first)
-##############################################################
-
-echo "Fetching latest changes from origin ..."
-git fetch origin --prune
-
-# We need the tags also. The standard "git fetch origin" call does
-# not appear to also grab the tags.
-git fetch origin --tags
-
-
-##############################################################
-# Setup
-##############################################################
-
-# Formats that are built by default for new releases
-declare -a formats
-formats=(
-  epub
-  html
-)
-
-branches=($(git branch -a | grep remotes | grep origin | grep -v "HEAD" | sed -e 's/ //g' -e 's#remotes/origin/##g'))
-latest_stable_branch=$(git branch -a | grep remotes | grep origin | grep -v "HEAD" | sed -e 's/ //g' -e 's#remotes/origin/##g' | grep -E 'v[0-9]+' | tail -n 1)
-dev_branches=($(git branch -a | grep remotes | grep origin | grep -v "HEAD" | sed -e 's/ //g' -e 's#remotes/origin/##g' | grep -v "$latest_stable_branch"))
-
-# Build release docs for latest official stable version
-latest_stable_tag=$(git tag --list 'v*' | sort --version-sort | grep -Eo '^v[.0-9]+$' | tail -n 1)
-
-# The latest stable tag, but without the leading 'v'
-latest_stable_version=$(echo $latest_stable_tag | sed "s/[A-Za-z]//g")
-
-# tarball representing the documentation for the latest stable release
-doc_tarball="rsyslog-doc-${latest_stable_version}.tar.gz"
-
-
-# Allow user to pass in the location for generated files
-if [[ -z ${1+x} ]]; then
-    output_dir="/tmp/rsyslog-doc-builds"
-    echo -e "\nWARNING: Output directory not specified, falling back to default: $output_dir"
-else
-    output_dir=$1
-    echo "Generated files will be placed in ${output_dir}"
-    # otherwise if user didn't specify, go ahead and set a default
-
-fi
-
 
 ##############################################################
 # Functions
 ##############################################################
+
+get_latest_stable_branch() {
+
+    git branch -a | \
+        grep remotes | \
+        grep origin | \
+        grep -v "HEAD" | \
+        sed -e 's/ //g' -e 's#remotes/origin/##g' | \
+        grep -E 'v[0-9]+' | \
+        tail -n 1
+}
+
+# This includes 'master', but intentionally excludes the stable branches
+# which master is periodically merged into
+get_dev_branches() {
+
+    git branch -a | \
+        grep remotes | \
+        grep origin | \
+        grep -v "HEAD" | \
+        sed -e 's/ //g' -e 's#remotes/origin/##g' | \
+        grep -v "$latest_stable_branch"
+
+}
 
 prep_branch_for_build() {
 
@@ -82,11 +49,69 @@ prep_branch_for_build() {
     git checkout origin/$branch ||
       { echo "[!] Checkout $branch failed... aborting"; exit 1; }
 
-    echo "Pull Branch $branch"
-    git pull origin $branch ||
-      { echo "[!] Pull $branch failed... aborting"; exit 1; }
-
 }
+
+
+
+##############################################################
+# Offer opportunity to stop before (destructive) work begins
+##############################################################
+
+echo ""
+echo "This script is intended to run with a clean repo version of the code."
+echo "Run the sphinx-build command manually if you want to see your uncommited changes."
+echo "If you run this script with uncommitted and un-pushed changes, YOU WILL LOSE THOSE CHANGES!"
+echo ""
+echo "Press Enter to continue or Ctrl-C to cancel...."
+read -r REPLY
+
+
+# Refresh local content
+echo "Fetching latest changes from origin ..."
+git fetch origin --prune --tags
+
+
+
+
+##############################################################
+# Setup
+##############################################################
+
+# Set to newlines only so spaces won't trigger a new array entry and so loops
+# will only consider items separated by newlines to be the next in the loop
+IFS=$'\n'
+
+# Formats that are built by default for new releases
+declare -a formats
+formats=(
+  epub
+  html
+)
+
+latest_stable_branch=$(get_latest_stable_branch)
+dev_branches=($(get_dev_branches))
+
+# Build release docs for latest official stable version
+latest_stable_tag=$(git tag --list 'v*' | sort --version-sort | grep -Eo '^v[.0-9]+$' | tail -n 1)
+
+# The latest stable tag, but without the leading 'v'
+latest_stable_version=$(echo $latest_stable_tag | sed "s/[A-Za-z]//g")
+
+# tarball representing the documentation for the latest stable release
+doc_tarball="rsyslog-doc-${latest_stable_version}.tar.gz"
+
+
+# Allow user to pass in the location for generated files
+# If user opted to not pass in the location, go ahead and set a default.
+if [[ -z ${1+x} ]]; then
+    output_dir="/tmp/rsyslog-doc-builds"
+    echo -e "\nWARNING: Output directory not specified, falling back to default: $output_dir"
+else
+    # Otherwise, if they DID pass in a value, use that.
+    output_dir=$1
+    echo "Generated files will be placed in ${output_dir}"
+fi
+
 
 
 ###############################################################
@@ -140,6 +165,7 @@ done
 # Build latest stable tag
 ###############################################################
 
+echo "Building latest stable tag: $latest_stable_tag"
 git reset --hard
 git clean --force -d
 git checkout $latest_stable_tag
@@ -148,7 +174,16 @@ git checkout $latest_stable_tag
 # the conf.py file will label generated content with specific date/commit
 # info for easy visual reference
 sphinx-build -b html source build -D release="$latest_stable_version" ||
-    { echo echo "[!] sphinx-build failed for $latest_stable_tag tag ... aborting"; exit 1; }
+    { echo "[!] sphinx-build failed for html format of $latest_stable_tag tag ... aborting"; exit 1; }
 
 tar -czf $output_dir/$doc_tarball source build LICENSE README.md build.sh ||
-    { echo echo "[!] tarball creation failed for $latest_stable_tag tag ... aborting"; exit 1; }
+    { echo "[!] tarball creation failed for $latest_stable_tag tag ... aborting"; exit 1; }
+
+
+
+###############################################################
+# Reset repo to master for next build
+###############################################################
+
+# This ensures that the build script is always at the latest version
+prep_branch_for_build master


### PR DESCRIPTION
@rgerhards I found some issues with the build script when attempting to use it as-is for automating regular builds of the branches. I'm not sure that I have all of them squashed, but this fixes at least the most glaring ones. I suspect I'll loop back to this script and make some further tweaks as part of another PR after I have a chance to spend some more time with it.

closes rsyslog/rsyslog-doc#464
