### PR TITLE
Minor fixup for c0fb71c

### DIFF
--- a/source/configuration/examples.rst
+++ b/source/configuration/examples.rst
@@ -34,7 +34,7 @@ A template that can be used for the database write (please note the SQL template
 
 The following template emulates
 `WinSyslog <http://www.winsyslog.com/en/>`_ format (it's an
-`Adiscon`_ format, you do not feel bad if
+`Adiscon <http://www.adiscon.com/>`_ format, you do not feel bad if
 you don't know it ;)). It's interesting to see how it takes different
 parts out of the date stamps. What happens is that the date stamp is
 split into the actual date and time and the these two are combined with

--- a/source/configuration/global/options/rsconf1_debugprintcfsyslinehandlerlist.rst
+++ b/source/configuration/global/options/rsconf1_debugprintcfsyslinehandlerlist.rst
@@ -11,7 +11,3 @@ Specifies whether or not the configuration file sysline handler list
 should be written to the debug log. Possible values: on/off. Default is
 on. Does not affect operation if debugging is disabled.
 
-**Sample:**
-
-````
-

--- a/source/configuration/global/options/rsconf1_debugprintmodulelist.rst
+++ b/source/configuration/global/options/rsconf1_debugprintmodulelist.rst
@@ -10,8 +10,3 @@ $DebugPrintModuleList
 Specifies whether or not the module list should be written to the debug
 log. Possible values: on/off. Default is on. Does not affect operation
 if debugging is disabled.
-
-**Sample:**
-
-````
-

--- a/source/configuration/global/options/rsconf1_debugprinttemplatelist.rst
+++ b/source/configuration/global/options/rsconf1_debugprinttemplatelist.rst
@@ -10,8 +10,3 @@ $DebugPrintTemplateList
 Specifies whether or not the template list should be written to the
 debug log. Possible values: on/off. Default is on. Does not affect
 operation if debugging is disabled..
-
-**Sample:**
-
-````
-


### PR DESCRIPTION
- Remove empty sections and trailing transition markers (reSTructuredText does not permit ending with a transition)
- Replace broken source link with full target link

refs rsyslog/rsyslog-doc#463, rsyslog/rsyslog-doc#455