### PR TITLE
re-add release_build.sh script: used by maintainer during release

### DIFF
--- a/release_build.sh
+++ b/release_build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# this is used to create an rsyslog release tarball.
+# it must be executed from the root of the rsyslog-doc
+# project.
+
+docfile=rsyslog-doc.tar.gz
+
+[ ! -d ./build ] || rm -rf ./build
+
+sphinx-build -b html source build || {
+	echo "sphinx-build failed... aborting"
+	exit 1
+}
+
+[ ! -e ./$docfile ] || rm -rf ./$docfile
+
+tar -czf $docfile build source LICENSE README.md build.sh || {
+	echo "Failed to create rsyslog-doc.tar.gz tarball..."
+	exit 1
+}


### PR DESCRIPTION
the build.sh does too many things that are not directly related
to release build process
  
closes https://github.com/rsyslog/rsyslog-doc/issues/469