### PR TITLE
obsolete format: fix default number of main message queue wrkr threads

### DIFF
--- a/source/configuration/global/index.rst
+++ b/source/configuration/global/index.rst
@@ -153,6 +153,6 @@ To understand queue parameters, read
    in ms (1000ms is 1sec!), default 60000 (1 minute)]
 -  **$MainMsgQueueType** [**FixedArray**/LinkedList/Direct/Disk]
 -  **$MainMsgQueueSaveOnShutdown**  [on/**off**]
--  **$MainMsgQueueWorkerThreads** <number>, num worker threads, default 1,
+-  **$MainMsgQueueWorkerThreads** <number>, num worker threads, default 2,
    recommended 1
 -  **$MainMsgQueueWorkerThreadMinumumMessages** <number>, default queue size/number of workers


### PR DESCRIPTION
Thanks to 朱继鹏 (github user jipengzhu) for alerting us on this
bug.

closes https://github.com/rsyslog/rsyslog/issues/1742