### PR TITLE
PROTOTYPE: Parameter formatting

### DIFF
--- a/source/_static/rsyslog.css
+++ b/source/_static/rsyslog.css
@@ -448,6 +448,13 @@ abbr, acronym {
     cursor: help;
 }
 
+/* Add extra space between parameter sections */
+div.section {
+    margin-top: 30px;
+}
+
+
+
 /* -- code displays --------------------------------------------------------- */
 
 pre {

--- a/source/conf.py
+++ b/source/conf.py
@@ -293,3 +293,9 @@ epub_author = u'Rainer Gerhards and Others'
 epub_contributor = u'Rsyslog Community'
 epub_publisher = 'http://www.rsyslog.com/'
 epub_description = u'Documentation for the rsyslog project'
+
+
+# http://www.sphinx-doc.org/en/stable/extdev/appapi.html#sphinx.application.Sphinx.add_stylesheet
+# Include our custom stylesheet in addition to specified theme
+def setup(app):
+    app.add_stylesheet('rsyslog.css')

--- a/source/configuration/modules/imuxsock.rst
+++ b/source/configuration/modules/imuxsock.rst
@@ -1,5 +1,6 @@
-imuxsock: Unix Socket Input
-***************************
+**********************************
+imuxsock: Unix Socket Input Module
+**********************************
 
 ===========================  ===========================================================================
 **Module Name:**             **imuxsock**
@@ -14,6 +15,11 @@ This module provides the ability to accept syslog messages from applications
 running on the local system via Unix sockets. Most importantly, this is the
 mechanism by which the :manpage:`syslog(3)` call delivers syslog messages
 to rsyslogd.
+
+.. seealso::
+
+   :doc:`omuxsock`
+
 
 Notable Features
 ================
@@ -41,192 +47,594 @@ Global Parameters
    See parameter descriptions and the :ref:`systemd-details-label` section for
    details.
 
--  **SysSock.IgnoreTimestamp** [**on**/off]
-   Ignore timestamps included in the messages, applies to messages
-   received via the system log socket.
 
--  **SysSock.IgnoreOwnMessages** [**on**/off] (available since 7.3.7)
-   Ignores messages that originated from the same instance of rsyslogd.
-   There usually is no reason to receive messages from ourselves. This
-   setting is vital when writing messages to the Linux journal. See
-   :doc:`omjournal <omjournal>` module documentation for a more
+SysSock.IgnoreTimestamp
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "``$SystemLogSocketIgnoreMsgTimestamp``"
+
+Ignore timestamps included in the messages, applies to messages received via
+the system log socket.
+
+
+SysSock.IgnoreOwnMessages
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "none"
+
+Ignores messages that originated from the same instance of rsyslogd.
+There usually is no reason to receive messages from ourselves. This
+setting is vital when writing messages to the systemd journal.
+
+.. versionadded:: 7.3.7
+
+.. seealso::
+
+   See :doc:`omjournal <omjournal>` module documentation for a more
    in-depth description.
 
--  **SysSock.Use** (imuxsock) [**on**/off] - Listen on the default local
-   log socket (``/dev/log``) or, if provided, use the log socket value
-   assigned to the ``SysSock.Name`` parameter instead of the default. This
-   is most useful if you run multiple instances of rsyslogd where only one
-   shall handle the system log socket.  Unless disabled by the
-   ``SysSock.Unlink`` setting, this socket is created upon rsyslog startup
-   and deleted upon shutdown, according to traditional syslogd behavior.
 
-   While the behavior of this parameter is different for systemd systems,
-   this parameter should not be disabled unless the intention is to only
-   listen on custom inputs. See the :ref:`systemd-details-label` section
-   for details.
+SysSock.Use
+^^^^^^^^^^^
 
--  **SysSock.Name** <name-of-socket> - specifies an alternate log socket
-   to be used instead of the default system log socket, traditionally
-   ``/dev/log``. Unless disabled by the ``SysSock.Unlink`` setting,
-   this socket is created upon rsyslog startup and deleted upon shutdown,
-   according to traditional syslogd behavior.
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
 
-   The behavior of this parameter is different for systemd systems. See the
-   the :ref:`systemd-details-label` section for details.
+   "binary", "on", "no", "``$OmitLocalLogging``"
 
--  **SysSock.FlowControl** [on/**off**] - specifies if flow control
-   should be applied to the system log socket.
+Listen on the default local log socket (``/dev/log``) or, if provided, use
+the log socket value assigned to the ``SysSock.Name`` parameter instead
+of the default. This is most useful if you run multiple instances of
+rsyslogd where only one shall handle the system log socket.  Unless
+disabled by the ``SysSock.Unlink`` setting, this socket is created
+upon rsyslog startup and deleted upon shutdown, according to
+traditional syslogd behavior.
 
--  **SysSock.UsePIDFromSystem** [on/**off**] - specifies if the pid
-   being logged shall be obtained from the log socket itself. If so, the
-   TAG part of the message is rewritten. It is recommended to turn this
-   option on, but the default is "off" to keep compatible with earlier
-   versions of rsyslog.
+The behavior of this parameter is different for systemd systems. For those
+systems, ``SysSock.Use`` still needs to be enabled, but the value of
+``SysSock.Name`` is ignored and the socket provided by systemd is used
+instead. If this parameter is *not* enabled, then imuxsock will only be
+of use if a custom input is configured.
 
--  **SysSock.RateLimit.Interval** [number] - specifies the rate-limiting
-   interval in seconds. Default value is 0, which turns off rate
-   limiting. Set it to a number of seconds (5 recommended) to activate
-   rate-limiting. The default of 0 has been chosen as people experienced
-   problems with this feature activated by default. Now it needs an
-   explicit opt-in by setting this parameter.
+See the :ref:`systemd-details-label` section for details.
 
--  **SysSock.RateLimit.Burst** [number] - specifies the rate-limiting
-   burst in number of messages. Default is 200.
 
--  **SysSock.RateLimit.Severity** [numerical severity] - specifies the
-   severity of messages that shall be rate-limited.
+SysSock.Name
+^^^^^^^^^^^^
 
--  **SysSock.UseSysTimeStamp** [**on**/off] the same as the input
-   parameter ``UseSysTimeStamp``, but for the system log socket. See
-   description there.
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
 
--  **SysSock.Annotate** <on/**off**> turn on annotation/trusted
-   properties for the system log socket.
+   "string", "/dev/log", "no", "``$SystemLogSocketName``"
 
--  **SysSock.ParseTrusted** <on/**off**> if Annotation is turned on,
-   create JSON/lumberjack properties out of the trusted properties
-   (which can be accessed via RainerScript JSON Variables, e.g. ``$!pid``)
-   instead of adding them to the message.
+Specifies an alternate log socket to be used instead of the default system
+log socket, traditionally ``/dev/log``. Unless disabled by the
+``SysSock.Unlink`` setting, this socket is created upon rsyslog startup
+and deleted upon shutdown, according to traditional syslogd behavior.
 
--  **SysSock.Unlink** <**on**/off> (available since 7.3.9)
-   if turned on (default), the system socket is unlinked and re-created
-   when opened and also unlinked when finally closed. Note that this
-   setting has no effect when running under systemd control (because
-   systemd handles the socket).
+The behavior of this parameter is different for systemd systems. See the
+the :ref:`systemd-details-label` section for details.
 
--  **sysSock.useSpecialParser** (available since 8.9.0)
-   The equivalent of the ``useSpecialParser`` input parameter for the
-   system socket.
 
--  **sysSock.parseHostname** (available since 8.9.0)
-   The equivalent of the ``parseHostname`` input parameter for the
-   system socket.
+SysSock.FlowControl
+^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$SystemLogFlowControl``"
+
+Specifies if flow control should be applied to the system log socket.
+
+
+SysSock.UsePIDFromSystem
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$SystemLogUsePIDFromSystem``"
+
+Specifies if the pid being logged shall be obtained from the log socket
+itself. If so, the TAG part of the message is rewritten. It is recommended
+to turn this option on, but the default is "off" to keep compatible
+with earlier versions of rsyslog.
+
+.. versionadded:: 5.7.0
+
+
+SysSock.RateLimit.Interval
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "0", "no", "``$SystemLogRateLimitInterval``"
+
+Specifies the rate-limiting interval in seconds. Default value is 0,
+which turns off rate limiting. Set it to a number of seconds (5
+recommended) to activate rate-limiting. The default of 0 has been
+chosen as people experienced problems with this feature activated
+by default. Now it needs an explicit opt-in by setting this parameter.
+
+
+SysSock.RateLimit.Burst
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "200", "no", "``$SystemLogRateLimitBurst``"
+
+Specifies the rate-limiting burst in number of messages.
+
+.. versionadded:: 5.7.1
+
+
+SysSock.RateLimit.Severity
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "1", "no", "``$SystemLogRateLimitSeverity``"
+
+Specifies the severity of messages that shall be rate-limited.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog#Severity_level
+
+
+SysSock.UseSysTimeStamp
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "``$SystemLogUseSysTimeStamp``"
+
+The same as the input parameter ``UseSysTimeStamp``, but for the system log
+socket. This parameter instructs ``imuxsock`` to obtain message time from
+the system (via control messages) instead of using time recorded inside
+the message. This may be most useful in combination with systemd. Due to
+the usefulness of this functionality, we decided to enable it by default.
+As such, the behavior is slightly different than previous versions.
+However, we do not see how this could negatively affect existing environments.
+
+.. versionadded:: 5.9.1
+
+
+SysSock.Annotate
+^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$SystemLogSocketAnnotate``"
+
+Turn on annotation/trusted properties for the system log socket. See
+the :ref:`trusted-properties-label` section for more info.
+
+
+SysSock.ParseTrusted
+^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$SystemLogParseTrusted``"
+
+If ``SysSock.Annotation`` is turned on, create JSON/lumberjack properties
+out of the trusted properties (which can be accessed via |FmtAdvancedName|
+JSON Variables, e.g. ``$!pid``) instead of adding them to the message.
+
+.. versionadded:: 7.2.7
+   |FmtAdvancedName| directive introduced
+
+.. versionadded:: 7.3.8
+   |FmtAdvancedName| directive introduced
+
+.. versionadded:: 6.5.0
+   |FmtObsoleteName| directive introduced
+
+
+SysSock.Unlink
+^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "none"
+
+If turned on (default), the system socket is unlinked and re-created
+when opened and also unlinked when finally closed. Note that this
+setting has no effect when running under systemd control (because
+systemd handles the socket. See the :ref:`systemd-details-label`
+section for details.
+
+.. versionadded:: 7.3.9
+
+
+SysSock.UseSpecialParser
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "none"
+
+The equivalent of the ``UseSpecialParser`` input parameter, but
+for the system socket. If turned on (the default) a special parser is
+used that parses the format that is usually used
+on the system log socket (the one :manpage:`syslog(3)` creates). If set to
+"off", the regular parser chain is used, in which case the format on the
+log socket can be arbitrary.
+
+.. note::
+
+   When the special parser is used, rsyslog is able to inject a more precise
+   timestamp into the message (it is obtained from the log socket). If the
+   regular parser chain is used, this is not possible.
+
+.. versionadded:: 8.9.0
+   The setting was previously hard-coded "on"
+
+
+SysSock.ParseHostname
+^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+.. note::
+
+   This option only has an effect if ``SysSock.UseSpecialParser`` is
+   set to "off".
+
+Normally, the local log sockets do *not* contain hostnames. If set
+to on, parsers will expect hostnames just like in regular formats. If
+set to off (the default), the parser chain is instructed to not expect
+them.
+
+.. versionadded:: 8.9.0
+
 
 Input Parameters
 ----------------
 
--  **ruleset** [name]
-   Binds specified ruleset to this input. If not set, the default
-   ruleset is bound. (available since 8.17.0)
+Ruleset
+^^^^^^^
 
--  **IgnoreTimestamp** [**on**/off]
-   Ignore timestamps included in messages received from the input being
-   defined.
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
 
--  **IgnoreOwnMessages** [**on**/off] (available since 7.3.7)
-   Ignore messages that originated from the same instance of rsyslogd.
-   There usually is no reason to receive messages from ourselves. This
-   setting is vital when writing messages to the Linux journal. See
-   :doc:`omjournal <omjournal>` module documentation for a more
+   "string", "default ruleset", "no", "none"
+
+Binds specified ruleset to this input. If not set, the default
+ruleset is bound.
+
+.. versionadded:: 8.17.0
+
+
+IgnoreTimestamp
+^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "``$InputUnixListenSocketIgnoreMsgTimestamp``"
+
+Ignore timestamps included in messages received from the input being
+defined.
+
+
+IgnoreOwnMessages
+^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "none"
+
+Ignore messages that originated from the same instance of rsyslogd.
+There usually is no reason to receive messages from ourselves. This
+setting is vital when writing messages to the systemd journal.
+
+.. versionadded:: 7.3.7
+
+.. seealso::
+
+   See :doc:`omjournal <omjournal>` module documentation for a more
    in-depth description.
 
--  **FlowControl** [on/**off**] - specifies if flow control should be
-   applied to the input being defined.
 
--  **RateLimit.Interval** [number] - specifies the rate-limiting
-   interval in seconds. Default value is 0, which turns off rate
-   limiting. Set it to a number of seconds (5 recommended) to activate
-   rate-limiting. The default of 0 has been chosen as people experienced
-   problems with this feature activated by default. Now it needs an
-   explicit opt-in by setting this parameter.
 
--  **RateLimit.Burst** [number] - specifies the rate-limiting burst in
-   number of messages. Default is 200.
 
--  **RateLimit.Severity** [numerical severity] - specifies the severity
-   of messages that shall be rate-limited.
+FlowControl
+^^^^^^^^^^^
 
--  **UsePIDFromSystem** [on/**off**] - specifies if the pid being logged
-   shall be obtained from the log socket itself. If so, the TAG part of
-   the message is rewritten. It is recommended to turn this option on,
-   but the default is "off" to keep compatible with earlier versions of
-   rsyslog.
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
 
--  **UseSysTimeStamp** [**on**/off] instructs imuxsock to obtain message
-   time from the system (via control messages) instead of using time
-   recorded inside the message. This may be most useful in combination
-   with systemd. Note: this option was introduced with version 5.9.1.
-   Due to the usefulness of it, we decided to enable it by default. As
-   such, 5.9.1 and above behave slightly different than previous
-   versions. However, we do not see how this could negatively affect
-   existing environments.
+   "binary", "off", "no", "``$InputUnixListenSocketFlowControl``"
 
--  **CreatePath** [on/**off**] - create directories in the socket path
-   if they do not already exist. They are created with 0755 permissions
-   with the owner being the process under which rsyslogd runs. The
-   default is not to create directories. Keep in mind, though, that
-   rsyslogd always creates the socket itself if it does not exist (just
-   not the directories by default).
-   This option is primarily considered useful for defining additional
-   sockets that reside on non-permanent file systems. As rsyslogd probably
-   starts up before the daemons that create these sockets, it is a vehicle
-   to enable rsyslogd to listen to those sockets even though their directories
-   do not yet exist.
+Specifies if flow control should be applied to the input being defined.
 
--  **Socket** <name-of-socket> adds additional unix socket, default none
-   -- former -a option
 
--  **HostName** <hostname> permits to override the hostname that shall
-   be used inside messages taken from the input that is being defined.
+RateLimit.Interval
+^^^^^^^^^^^^^^^^^^
 
--  **Annotate** <on/**off**> turn on annotation/trusted properties for
-   the input that is being defined.
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
 
--  **ParseTrusted** <on/**off**> equivalent to the ``SysSock.ParseTrusted``
-   module parameter, but applies to the input that is being defined.
+   "integer", "0", "no", "``$IMUXSockRateLimitInterval``"
 
--  **Unlink** <**on**/off> (available since 7.3.9)
-   if turned on (default), the socket is unlinked and re-created when
-   opened and also unlinked when finally closed. Set it to off if you
-   handle socket creation yourself. Note that handling socket creation
-   oneself has the advantage that a limited amount of messages may be
-   queued by the OS if rsyslog is not running.
+Specifies the rate-limiting interval in seconds. Default value is 0, which
+turns off rate limiting. Set it to a number of seconds (5 recommended)
+to activate rate-limiting. The default of 0 has been chosen as people
+experienced problems with this feature activated by default. Now it
+needs an explicit opt-in by setting this parameter.
 
--  **useSpecialParser** <**on**/off> (available since 8.9.0)
-   If turned on (the default and the way it was up until 8.8.0) a
-   special parser is used that parses the format that is usually
-   used on the system log socket (the one :manpage:`syslog(3)` creates).
-   If set to "off", the regular parser chain is used, in which case
-   the format on the log socket can be arbitrary.
-   Note that when the special parser is used, rsyslog is able to
-   inject a more precise timestamp into the message (it is obtained
-   from the log socket). If the regular parser chain is used, this
-   is not possible.
 
--  **parseHostname** <on/**off**> (available since 8.9.0)
-   Normally, the local log sockets do *not* contain hostnames. With
-   this directive, the parser chain can be instructed to not
-   expect them (setting "off", the default). If set to on, parsers
-   will expect hostnames just like in regular formats.
-   Note: this option only has an effect if ``useSpecialParsers`` is
-   set to "off".
+RateLimit.Burst
+^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "200", "no", "``$IMUXSockRateLimitBurst``"
+
+Specifies the rate-limiting burst in number of messages.
+
+.. versionadded:: 5.7.1
+
+
+RateLimit.Severity
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "1", "no", "``$IMUXSockRateLimitSeverity``"
+
+Specifies the severity of messages that shall be rate-limited.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog#Severity_level
+
+
+UsePIDFromSystem
+^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$InputUnixListenSocketUsePIDFromSystem``"
+
+Specifies if the pid being logged shall be obtained from the log socket
+itself. If so, the TAG part of the message is rewritten. It is
+recommended to turn this option on, but the default is "off" to keep
+compatible with earlier versions of rsyslog.
+
+
+UseSysTimeStamp
+^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "``$InputUnixListenSocketUseSysTimeStamp``"
+
+This parameter instructs ``imuxsock`` to obtain message time from
+the system (via control messages) instead of using time recorded inside
+the message. This may be most useful in combination with systemd. Due to
+the usefulness of this functionality, we decided to enable it by default.
+As such, the behavior is slightly different than previous versions.
+However, we do not see how this could negatively affect existing environments.
+
+.. versionadded:: 5.9.1
+
+
+CreatePath
+^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$InputUnixListenSocketCreatePath``"
+
+Create directories in the socket path if they do not already exist.
+They are created with 0755 permissions with the owner being the
+process under which rsyslogd runs. The default is not to create
+directories. Keep in mind, though, that rsyslogd always creates
+the socket itself if it does not exist (just not the directories
+by default).
+
+This option is primarily considered useful for defining additional
+sockets that reside on non-permanent file systems. As rsyslogd probably
+starts up before the daemons that create these sockets, it is a vehicle
+to enable rsyslogd to listen to those sockets even though their directories
+do not yet exist.
+
+.. versionadded:: 4.7.0
+.. versionadded:: 5.3.0
+
+
+Socket
+^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "``$AddUnixListenSocket``"
+
+Adds additional unix socket. Formerly specified with the ``-a`` option.
+
+
+HostName
+^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "NULL", "no", "``$InputUnixListenSocketHostName``"
+
+Allows overriding the hostname that shall be used inside messages
+taken from the input that is being defined.
+
+
+Annotate
+^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$InputUnixListenSocketAnnotate``"
+
+Turn on annotation/trusted properties for the input that is being defined.
+See the :ref:`trusted-properties-label` section for more info.
+
+
+ParseTrusted
+^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "``$ParseTrusted``"
+
+Equivalent to the ``SysSock.ParseTrusted`` module parameter, but applies
+to the input that is being defined.
+
+
+Unlink
+^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "``none``"
+
+If turned on (default), the socket is unlinked and re-created when opened
+and also unlinked when finally closed. Set it to off if you handle socket
+creation yourself.
+
+.. note::
+
+   Note that handling socket creation oneself has the
+   advantage that a limited amount of messages may be queued by the OS
+   if rsyslog is not running.
+
+.. versionadded:: 7.3.9
+
+
+UseSpecialParser
+^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "none"
+
+Equivalent to the ``SysSock.UseSpecialParser`` module parameter, but applies
+to the input that is being defined.
+
+.. versionadded:: 8.9.0
+   The setting was previously hard-coded "on"
+
+
+ParseHostname
+^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+Equivalent to the ``SysSock.ParseHostname`` module parameter, but applies
+to the input that is being defined.
+
+.. versionadded:: 8.9.0
+
 
 .. _rate-limiting-label:
 
 Input rate limiting
 ===================
-
-.. versionadded:: 5.7.1
 
 rsyslog supports (optional) input rate limiting to guard against the problems
 of a wild running logging process. If more than
@@ -238,19 +646,21 @@ many it has dropped once the interval has expired AND the next message is
 logged. Rate-limiting depends on ``SCM\_CREDENTIALS``. If the platform does
 not support this socket option, rate limiting is turned off. If multiple
 sockets are configured, rate limiting works independently on each of
-them (that should be what you usually expect). The same functionality is
-available for additional log sockets, in which case the config
-statements just use the prefix RateLimit... but otherwise works exactly
-the same. When working with severities, please keep in mind that higher
-severity numbers mean lower severity and configure things accordingly.
-To turn off rate limiting, set the interval to zero.
+them (that should be what you usually expect).
+
+The same functionality is available for additional log sockets, in which
+case the config statements just use the prefix RateLimit... but otherwise
+works exactly the same. When working with severities, please keep in mind
+that higher severity numbers mean lower severity and configure things
+accordingly. To turn off rate limiting, set the interval to zero.
+
+.. versionadded:: 5.7.1
+
 
 .. _trusted-properties-label:
 
 Trusted (syslog) properties
 ===========================
-
-.. versionadded:: 5.9.4
 
 rsyslog can annotate messages from system log sockets (via imuxsock) with
 so-called `Trusted syslog
@@ -270,6 +680,14 @@ the end. For these reasons, the feature is **not enabled by default**.
 If you want to use it, you must turn it on (via
 ``SysSock.Annotate`` and ``Annotate``).
 
+.. versionadded:: 5.9.4
+
+.. seealso::
+
+   `What are "trusted properties"?
+   <http://www.rsyslog.com/what-are-trusted-properties/>`_
+
+
 .. _flow-control-label:
 
 Flow-control of Unix log sockets
@@ -288,6 +706,7 @@ need to enable it via the ``SysSock.FlowControl`` and ``FlowControl`` config
 directives. Just make sure you have thought about the implications and have
 tested the change on a non-production system first.
 
+
 .. _application-timestamps-label:
 
 Control over application timestamps
@@ -300,6 +719,7 @@ information). This seems to be consistent with what sysklogd has done for
 many years. Alternate behaviour may be desirable if gateway-like processes
 send messages via the local log slot. In that case, it can be enabled via
 the ``SysSock.IgnoreTimestamp`` and ``IgnoreTimestamp`` config directives.
+
 
 .. _systemd-details-label:
 
@@ -317,21 +737,24 @@ access to logging data via the ``/run/systemd/journal/syslog`` log socket.
 This log socket is provided by the ``syslog.socket`` file that is shipped
 with systemd.
 
-.. versionadded:: 8.32.0
-
-   rsyslog emits an informational message noting the system log socket provided
-   by systemd.
-
 The imuxsock module can still be used in this setup and provides superior
 performance over :doc:`imjournal <imjournal>`, the alternative journal input
 module.
 
 .. note::
 
-  It must be noted, however, that the journal tends to drop messages
-  when it becomes busy instead of forwarding them to the system log socket.
-  This is because the journal uses an async log socket interface for forwarding
-  instead of the traditional synchronous one.
+   It must be noted, however, that the journal tends to drop messages
+   when it becomes busy instead of forwarding them to the system log socket.
+   This is because the journal uses an async log socket interface for forwarding
+   instead of the traditional synchronous one.
+
+.. versionadded:: 8.32.0
+   rsyslog emits an informational message noting the system log socket provided
+   by systemd.
+
+.. seealso::
+
+   :doc:`imjournal`
 
 
 Handling of sockets
@@ -342,8 +765,14 @@ what system socket to use, which sockets rsyslog should listen on, whether
 the sockets should be created and how rsyslog should handle the sockets when
 shutting down.
 
+.. seealso::
+
+   `Writing syslog Daemons Which Cooperate Nicely With systemd
+   <https://www.freedesktop.org/wiki/Software/systemd/syslog/>`_
+
+
 Step 1: Select name of system socket
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. If the user has not explicitly chosen to set ``SysSock.Use="off"`` then
    the default listener socket (aka, "system log socket" or simply "system
@@ -363,12 +792,12 @@ Step 1: Select name of system socket
 
 
 Step 2: Listen on specified sockets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-  This is true for all sockets, be it system socket or not. But if
-  ``SysSock.Use="off"``, the system socket will not be listened on.
+   This is true for all sockets, be it system socket or not. But if
+   ``SysSock.Use="off"``, the system socket will not be listened on.
 
 rsyslog evaluates the list of sockets it has been asked to activate:
 
@@ -380,12 +809,13 @@ If it was passed in via systemd, the socket is used as-is (e.g., not recreated
 upon rsyslog startup), otherwise if not passed in via systemd the log socket
 is unlinked, created and opened.
 
+
 Step 3: Shutdown log sockets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-  This is true for all sockets, be it system socket or not.
+   This is true for all sockets, be it system socket or not.
 
 Upon shutdown, rsyslog processes each socket it is listening on and evaluates
 it. If the socket was originally passed in via systemd (name is checked), then
@@ -403,23 +833,12 @@ Statistic Counter
 
 This plugin maintains a global :doc:`statistics <../rsyslog_statistic_counter>` with the following properties:
 
--  **submitted** - total number of messages submitted for processing since startup
+- ``submitted`` - total number of messages submitted for processing since startup
 
--  **ratelimit.discarded** - number of messages discarded due to rate limiting
+- ``ratelimit.discarded`` - number of messages discarded due to rate limiting
 
--  **ratelimit.numratelimiters** - number of currently active rate limiters
-   (smal data structures used for the rate limiting logic)
-
-See Also
-========
-
--  `What are "trusted
-   properties"? <http://www.rsyslog.com/what-are-trusted-properties/>`_
--  `Why does imuxsock not work on
-   Solaris? <http://www.rsyslog.com/why-does-imuxsock-not-work-on-solaris/>`_
-
-- `Writing syslog Daemons Which Cooperate Nicely With systemd
-  <https://www.freedesktop.org/wiki/Software/systemd/syslog/>`_
+- ``ratelimit.numratelimiters`` - number of currently active rate limiters
+  (small data structures used for the rate limiting logic)
 
 
 Caveats/Known Bugs
@@ -438,7 +857,11 @@ Caveats/Known Bugs
 - Application timestamps are ignored by default. See the
   :ref:`application-timestamps-label` section for details.
 
+- `imuxsock does not work on Solaris
+  <http://www.rsyslog.com/why-does-imuxsock-not-work-on-solaris/>`_
+
 .. todolist::
+
 
 Examples
 ========
@@ -474,30 +897,30 @@ on via ``SysSock.Annotate`` for the system log socket and ``Annotate`` for
 inputs.
 
 Append to end of message
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following sample is used to activate message annotation and thus
 trusted properties on the system log socket. These trusted properties
 are appended to the end of each message.
 
 .. code-block:: none
-  :emphasize-lines: 2
+   :emphasize-lines: 2
 
-  module(load="imuxsock" # needs to be done just once
-         SysSock.Annotate="on")
+   module(load="imuxsock" # needs to be done just once
+            SysSock.Annotate="on")
 
 
 Store in JSON message properties
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following sample is similiar to the first one, but enables parsing of
 trusted properties, which places the results into JSON/lumberjack variables.
 
 .. code-block:: none
-  :emphasize-lines: 2
+   :emphasize-lines: 2
 
-  module(load="imuxsock"
-         SysSock.Annotate="on" SysSock.ParseTrusted="on")
+   module(load="imuxsock"
+            SysSock.Annotate="on" SysSock.ParseTrusted="on")
 
 Read log data from jails
 ------------------------
@@ -506,13 +929,13 @@ The following sample is a configuration where rsyslogd pulls logs from
 two jails, and assigns different hostnames to each of the jails:
 
 .. code-block:: none
-  :emphasize-lines: 3,4,5
+   :emphasize-lines: 3,4,5
 
-  module(load="imuxsock") # needs to be done just once
-  input(type="imuxsock"
-        HostName="jail1.example.net"
-        Socket="/jail/1/dev/log") input(type="imuxsock"
-        HostName="jail2.example.net" Socket="/jail/2/dev/log")
+   module(load="imuxsock") # needs to be done just once
+   input(type="imuxsock"
+         HostName="jail1.example.net"
+         Socket="/jail/1/dev/log") input(type="imuxsock"
+         HostName="jail2.example.net" Socket="/jail/2/dev/log")
 
 Read from socket on temporary file system
 -----------------------------------------
@@ -524,12 +947,12 @@ to create the socket directories, because it otherwise can not open the
 socket and thus not listen to openssh messages.
 
 .. code-block:: none
-  :emphasize-lines: 3,4
+   :emphasize-lines: 3,4
 
-  module(load="imuxsock") # needs to be done just once
-  input(type="imuxsock"
-        Socket="/var/run/sshd/dev/log"
-        CreatePath="on")
+   module(load="imuxsock") # needs to be done just once
+   input(type="imuxsock"
+         Socket="/var/run/sshd/dev/log"
+         CreatePath="on")
 
 
 Disable rate limiting
@@ -539,8 +962,8 @@ The following sample is used to turn off input rate limiting on the
 system log socket.
 
 .. code-block:: none
-  :emphasize-lines: 2
+   :emphasize-lines: 2
 
-  module(load="imuxsock" # needs to be done just once
-         SysSock.RateLimit.Interval="0") # turn off rate limiting
+   module(load="imuxsock" # needs to be done just once
+            SysSock.RateLimit.Interval="0") # turn off rate limiting
 


### PR DESCRIPTION
This is early work to prototype a consistent format for module parameters. 

Some of the formats I've observed:

- Bullet points
- use of  `.. function::` directives with "default" statement just beneath
- ... with "default" statement at the end
- bullet point, noting whether parameter is mandatory and then default value (one-liner)

I don't know what the right answer is, so this PR is more of a fence post for conversation than anything else. Because I recently worked on the imuxsock module doc, I'll test some changes to that doc first.

- Refs: #6

---

Live view of work:

- [section headers with `obsolete legacy` format directives](http://rsyslog.whyaskwhy.org/imuxsock_parameter_syntax/configuration/modules/imuxsock.html)
