### PR TITLE
Mute "unknown mimetype" warnings for epub format

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.abspath('_ext'))
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.5.1'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.

--- a/source/conf.py
+++ b/source/conf.py
@@ -144,6 +144,9 @@ todo_include_todos = True
 # is False.
 todo_emit_warnings = True
 
+# Supress "unknown mimetype for ..." warnings
+suppress_warnings = ['epub.unknown_project_files']
+
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
Add option to disable warning for unknown project files to Sphinx build configuration file. This mutes the spurious warnings shown when building epub files.

closes rsyslog/rsyslog-doc#477