### PR TITLE
Update build script to accept version/release info from command-line

### DIFF
--- a/release_build.sh
+++ b/release_build.sh
@@ -31,7 +31,7 @@ sphinx-build -D version="$version" -D release="$release" -b $format source build
 
 [ ! -e ./$docfile ] || rm -rf ./$docfile
 
-tar -czf $docfile build source LICENSE README.md build.sh || {
+tar -czf $docfile build source LICENSE README.md || {
 	echo "Failed to create rsyslog-doc.tar.gz tarball..."
 	exit 1
 }

--- a/release_build.sh
+++ b/release_build.sh
@@ -4,11 +4,27 @@
 # it must be executed from the root of the rsyslog-doc
 # project.
 
+
+if [ -z $1 ]; then
+    echo "[!] Release version number missing. Please run $0 again"
+    echo "    with the stable x.y release number that reflects HEAD"
+    exit 1
+else
+    version="$1"
+fi
+
+release="${version}.0"
+
 docfile=rsyslog-doc.tar.gz
+
+# Hard-code html format for now since that is the only format
+# officially provided
+format="html"
 
 [ ! -d ./build ] || rm -rf ./build
 
-sphinx-build -b html source build || {
+
+sphinx-build -D version="$version" -D release="$release" -b $format source build || {
 	echo "sphinx-build failed... aborting"
 	exit 1
 }


### PR DESCRIPTION
Add support for pulling in version number from command-line. This can be used in overriding the hash-based version number now used by default for devel builds.

Additionally, the release build script no longer attempts to include build scripts in the doc release tarball.

closes rsyslog/rsyslog-doc#482