### PR TITLE
begin documentation on rsyslog containers

### DIFF
--- a/source/containers/container_features.rst
+++ b/source/containers/container_features.rst
@@ -1,0 +1,9 @@
+Container-Features
+------------------
+
+Upon start, rsyslog checks if it is running as pid 1. If so, this is
+a clear indication it is running inside a container. This changes
+some parameter defaults:
+
+- ctl-c is enabled
+- no pid file is written

--- a/source/containers/docker_specifics.rst
+++ b/source/containers/docker_specifics.rst
@@ -1,0 +1,23 @@
+docker specifics
+----------------
+
+This page talks about docker, as this is the platform the rsyslog
+team has hands-on experience with. Some or all of the information
+might also apply to other solutions.
+
+Potential Trouble causes:
+
+- container terminate timeout
+
+  By default, a docker container has 10 seconds to shut down. If rsyslog
+  is running with a large queue that needs to be persisted to disk,
+  that amount of time might be insufficient. This can lead to a hard
+  kill of rsyslog and potentially cause queue corruption.
+
+- shared work directories
+
+  Shared work directories call for problems and shall be avoided. If
+  multiple instances use the same work directory, the may even overwrite
+  some files, resulting in a total mess. Each container instance should
+  have its own work directory.
+

--- a/source/containers/index.rst
+++ b/source/containers/index.rst
@@ -1,0 +1,20 @@
+rsyslog and containers
+======================
+
+In this chapter, we describe how rsyslog can be used together with
+containers.
+
+All versions of rsyslog work well in containers. Versions beginning with
+8.32.0 have also been made explicitely container-aware and provide some
+extra features that are useful inside containers.
+
+Note: the sources for docker containers created by the rsyslog project
+can be found at https://github.com/rsyslog/rsyslog-docker - these may
+be useful as a starting point for similar efforts. Feedback, bug
+reports and pull requests are also appreciated for this project.
+
+.. toctree::
+   :maxdepth: 2
+   
+   container_features
+   docker_specifics

--- a/source/index.rst
+++ b/source/index.rst
@@ -26,6 +26,7 @@ Manual
    
    installation/index
    configuration/index
+   containers/index
    troubleshooting/index
    faq/index
    concepts/index


### PR DESCRIPTION
The idea is to provide useful information as early as possible and
extend it as it grows. While this at first may look sparse, I think
it is the best way forward. The alternative would be to wait a
long time until we know "everything" and can document it.

see also https://github.com/rsyslog/rsyslog-doc/issues/491