### PR TITLE
Update build process to default to static value builds, use verbose details for dev builds when available

### DIFF
--- a/BUILDS_README.md
+++ b/BUILDS_README.md
@@ -1,0 +1,162 @@
+# rsyslog-doc builds: A guide to building the rsyslog documentation for maintainers and contributors
+
+*Documentation for building the documentation for ...*
+
+This doc is intended for maintainers and regular contributors to
+the project. The `README.md` doc covers the basic steps for one-off
+builds from the `master` branch.
+
+In all cases, the version number and release string do not *need* to be
+manually specified, though the directions do provide steps for doing so
+in at least one case.
+
+Directions in this doc provide examples for building HTML and epub formats. See
+the official http://www.sphinx-doc.org/en/stable/invocation.html doc for other
+formats that Sphinx is capable of building. Some formats may require
+installation of other packages for your operating system that are not
+installed by following the current setup/prep directions in the `README.md`
+file.
+
+
+## Generating release version of the docs
+
+These steps guide you through the steps necessary to build a version of the
+docs that match those hosted on rsyslog.com or that are available via
+distro packages.
+
+These directions assume that `8.33.0` is the latest stable release version.
+Substitute the actual latest stable release version as you following the
+steps in this document.
+
+
+### Maintainer
+
+#### Notes
+
+- These directions are generalized as the specific steps are highly dependent
+  on the production build/hosting environment.
+- All steps provided are intended to be run from the maintainer's dev
+  workstation.
+
+#### Directions
+
+1. Review the README.md file for instructions that cover installing `pip`,
+   setting up the virtual environment and installing the latest version
+   of the Sphinx package.
+1. Clone the https://github.com/rsyslog-doc.git repo
+1. Merge `master` into the current stable branch (e.g., `v8-stable`)
+1. Tag the stable branch
+1. Push all changes to the remote
+1. Run the `release_build.sh` script
+1. Sync the contents of the `build` directory over to the web server
+1. Sync the latest release doc tarball to where the previous release
+   tarball is hosted. Update references to this tarball as necessary.
+
+
+### Contributors
+
+#### Obtain stable docs 
+
+You have several options:
+
+- Download the release tarball
+  (http://www.rsyslog.com/download/download-v8-stable/)
+- Download a zip file from GitHub
+- Clone GitHub repo and checkout the latest stable tag
+
+#### Build from official release tarball
+
+1. Decompress the tarball
+1. Change your current working directory to that of the directory containing
+   the `source` directory, `README.md` and other content that was within
+   the tarball
+    - For example, `cd /tmp/rsyslog-8.33.0`
+      (the `rsyslog-8.33.0` folder is within the tarball)
+1. Run `sphinx -b html source build`
+
+You may need to first follow the directions in the `README.md` doc to create
+or activate your virtual environment if the `sphinx` package is not already
+installed and known to your installation of Python.
+
+#### Build from GitHub download
+
+1. Visit https://github.com/rsyslog/rsyslog-doc
+1. Click on 'Branch: master' and choose 'Tags' from the right-column
+1. Select the `v8.33.0` tag
+1. Click on the 'Clone or download' green button to the far right
+1. Click 'Download ZIP' and save the file to your system
+1. Decompress the zip file
+1. Change your current working directory to that of the directory containing
+   the `source` directory, `README.md` and other content that was within
+   the tarball.
+    - For example, `cd C:\users\deoren\Downloads\rsyslog-8.33.0`
+      (the `rsyslog-8.33.0` folder is within the tarball)
+1. `sphinx -D version="8.33" release="8.33.0" -b html source build`
+    - You have to specify the `version` and `release` values here for now
+      because we do not modify the `source/conf.py` file in the stable branch
+      or its tags to hard-code the new version number.
+
+You may need to first follow the directions in the `README.md` doc to create
+or activate your virtual environment if the `sphinx` package is not already
+installed and known to your installation of Python.
+
+#### Build from Git repo
+
+1. Review the `README.md` file for instructions that cover installing `pip`,
+   setting up the virtual environment and installing the latest version
+   of the Sphinx package.
+1. Run `git clone https://github.com/rsyslog-doc.git`
+1. Run `git checkout v8.33.0`
+1. Run `sphinx -D version="8.33" release="8.33.0" -b html source build`
+
+You may need to first follow the directions in the `README.md` doc to create
+or activate your virtual environment if the `sphinx` package is not already
+installed and known to your installation of Python.
+
+
+## Generating development builds
+
+### Obtain docs
+
+You have several options for obtaining a snapshot of the branch you would
+like to build (most often this is the `master` branch):
+
+- Download a zip file from GitHub
+- Clone GitHub repo using Git
+
+We do not (currently) build tarballs ourselves for in-development snapshots
+of the docs.
+
+
+### Build from GitHub download
+
+These directions assume that you wish to build the docs from the `master`
+branch. Substitute `master` for any other branch that you wish to build.
+
+1. Follow the steps previously given for downloading the zip file from GitHub,
+   this time substituting the tag download option for the branch you wish
+   to obtain doc sources for.
+1. Decompress the zip file and change your current working directory to
+   that path.
+1. Run `sphinx -D release="dev-build" -b html source build` to generate
+   HTML format and `sphinx -b epub source build` to build an epub file.
+
+
+
+### Build from Git repo
+
+These directions assume that you wish to build the docs from the `master`
+branch. Substitute `master` for any other branch that you wish to build.
+
+The Sphinx build configuration file will attempt to pull the needed information
+from the Git repo in order to generate a "dev build" release string. This
+release string is prominently displayed in various places throughout the docs
+and is useful to identify a dev build from a release set of documentation.
+
+1. Review the README.md file for instructions that cover installing `pip`,
+   setting up the virtual environment and installing the latest version
+   of the Sphinx package.
+1. Run `git clone https://github.com/rsyslog-doc.git`
+1. Run `git checkout master`
+1. Run `sphinx -b html source build` to generate HTML format and
+   `sphinx -b epub source build` to build an epub file.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-rsyslog-docs
-============
+# rsyslog-docs
 
-Documentation for the rsyslog project
--------------------------------------
+## Documentation for the rsyslog project
 
 Documentation for rsyslog is generated with the (Python) Sphinx documentation
 processor. There is also a procedure which automatically picks up the most
 recent doc from the git archive, generates the html pages and uploads them
 to rsyslog.com.
+
+In addition to the directions here, there is also a separate
+[BUILDS_README.md](BUILDS_README.md) file for use by rsyslog-doc team
+members. This doc is used as a quick reference for those who regularly
+provide dev and official release builds of the documentation.
 
 ## Learning the doc tools
 

--- a/release_build.sh
+++ b/release_build.sh
@@ -1,15 +1,44 @@
 #!/bin/bash
 
-# this is used to create an rsyslog release tarball.
-# it must be executed from the root of the rsyslog-doc
-# project.
-
-
 # Do not allow use of unitilized variables
 set -u
 
 # Exit if any statement returns a non-true value
 set -e
+
+
+# Read the riot act, give user an option to bail before building the docs
+
+echo <<DISCLAIMER "
+
+#######################################################################
+#                                                                     #
+# Purpose: Create an official rsyslog docs release tarball            #
+#                                                                     #
+# Before proceeding, please confirm that you have performed the       #
+# following steps:                                                    #
+#                                                                     #
+# 1. Manually fetched, merged and tagged the changes to the stable    #
+#    branch that are intended to reflect the latest release.          #
+#                                                                     #
+# 2. Checkout the latest tag (or stable branch)                       #
+#                                                                     #
+# 3. Remove uncommitted files to help prevent them from being         #
+#    included in the release tarball                                  #
+#                                                                     #
+# These steps can be automated, but have been left as-is for this     #
+# version of the release script. If desired, a future version of      #
+# the script can be enhanced to include this functionality.           #
+#                                                                     #
+#                                                                     #
+#             PRESS ENTER TO CONTINUE OR CTRL+C TO CANCEL             #
+#                                                                     #
+#######################################################################
+"
+DISCLAIMER
+
+read -r REPLY
+
 
 
 #####################################################################

--- a/release_build.sh
+++ b/release_build.sh
@@ -1,37 +1,133 @@
-#!/bin/sh
+#!/bin/bash
 
 # this is used to create an rsyslog release tarball.
 # it must be executed from the root of the rsyslog-doc
 # project.
 
 
-if [ -z $1 ]; then
-    echo "[!] Release version number missing. Please run $0 again"
-    echo "    with the stable x.y release number that reflects HEAD"
-    exit 1
-else
-    version="$1"
-fi
+# Do not allow use of unitilized variables
+set -u
 
-release="${version}.0"
+# Exit if any statement returns a non-true value
+set -e
 
-docfile=rsyslog-doc-$1.tar.gz
+
+#####################################################################
+# Functions
+#####################################################################
+
+get_release_version() {
+
+	# Retrieve the list of Git tags and return the newest without
+    # the leading 'v' prefix character
+	git tag --list 'v*' | \
+	sort --version-sort | \
+	grep -Eo '^v[.0-9]+$' | \
+	tail -n 1 |\
+	sed "s/[A-Za-z]//g"
+}
+
+
+#####################################################################
+# Setup
+#####################################################################
+
+# The latest stable tag, but without the leading 'v'
+# Format: X.Y.Z
+release=$(get_release_version)
+
+# The release version, but without the trailing '.0'
+# Format: X.Y
+version=$(echo $release | sed 's/.0//')
+
+# Use the full version number
+docfile=rsyslog-doc-${release}.tar.gz
 
 # Hard-code html format for now since that is the only format
 # officially provided
 format="html"
 
-[ ! -d ./build ] || rm -rf ./build
+# The build conf used to generate release output files. Included
+# in the release tarball and needs to function as-is outside
+# of a Git repo (e.g., no ".git" directory present).
+sphinx_build_conf_prod="source/conf.py"
 
 
-sphinx-build -D version="$version" -D release="$release" -b $format source build || {
+#####################################################################
+# Sanity checks
+#####################################################################
+
+[ -d ./.git ] || {
+    echo "[!] Pre-build check fail: .git directory missing"
+    echo "    Run $0 again from a clone of the rsyslog-doc repo."
+    exit 1
+}
+
+
+#####################################################################
+# Fill out template
+#####################################################################
+
+# To support building from sources included in the tarball AND
+# to allow dynamic version generation we modify the placeholder values
+# in the Sphinx build configuration file to reflect the latest stable
+# version. Without this (e.g., if someone just calls sphinx-build
+# directly), then dev build values will be automatically calculated
+# using info from the Git repo if available, or will fallback to
+# the placeholder values provided for non-Git builds (e.g., someone
+# downloads the 'master' branch as a zip file from GitHub).
+
+sed -r -i "s/^version.*$/version = \'${version}\'/" ./${sphinx_build_conf_prod} || {
+    echo "[!] Failed to replace version placeholder in Sphinx build conf template."
+    exit 1
+}
+
+sed -r -i "s/^release.*$/release = \'${release}\'/" ./${sphinx_build_conf_prod} || {
+    echo "[!] Failed to replace release placeholder in Sphinx build conf template."
+    exit 1
+}
+
+
+#####################################################################
+# Cleanup from last run
+#####################################################################
+
+[ ! -d ./build ] || rm -rf ./build || {
+    echo "[!] Failed to prune old build directory."
+    exit 1
+}
+
+[ ! -e ./$docfile ] || rm -f ./$docfile || {
+    echo "[!] Failed to prune $docfile tarball"
+    exit 1
+}
+
+
+#####################################################################
+# Build HTML format
+#####################################################################
+
+sphinx-build -b $format source build || {
 	echo "sphinx-build failed... aborting"
 	exit 1
 }
 
-[ ! -e ./$docfile ] || rm -rf ./$docfile
+
+#####################################################################
+# Create dist tarball
+#####################################################################
 
 tar -czf $docfile build source LICENSE README.md || {
 	echo "Failed to create $docfile tarball..."
 	exit 1
+}
+
+
+#####################################################################
+# Revert local changes to Sphinx config file
+#####################################################################
+
+git checkout ./${sphinx_build_conf_prod} || {
+       echo "[!] Failed to restore Sphinx build config to repo version"
+       exit 1
 }

--- a/source/conf_helpers.py
+++ b/source/conf_helpers.py
@@ -1,0 +1,110 @@
+# Helper functions for main conf.py Sphinx build configuration
+
+import datetime
+import re
+import subprocess
+
+def get_current_branch():
+    """Return the current branch we are on or the branch that the detached head
+    is pointed to"""
+
+    current_branch = subprocess.check_output(
+        ['git', 'rev-parse', '--abbrev-ref', "HEAD"]
+        ).decode("utf-8").strip()
+
+    if current_branch == 'HEAD':
+        # This means we are operating in a detached head state, will need to
+        # parse out the branch that the commit is from.
+
+        # Decode "bytes" type to UTF-8 sting to avoid Python 3 error:
+        # "TypeError: a bytes-like object is required, not 'str'""
+        # https://docs.python.org/3/library/stdtypes.html#bytes.decode
+        branches = subprocess.check_output(['git', 'branch']).decode('utf-8').split('\n')
+        for branch in branches:
+
+            # Git marks the current branch, or in this case the branch
+            # we are currently detached from with an asterisk
+            if '*' in branch:
+                # Split on the remote/branch separator, grab the
+                # last entry in the list and then strip off the trailing
+                # parentheis
+                detached_from_branch = branch.split('/')[-1].replace(')', '')
+
+                return detached_from_branch
+
+    else:
+        # The assumption is that we are on a branch at this point. Return that.
+        return current_branch
+
+
+def get_current_stable_version():
+    """Return the current X.Y stable version number from the latest git tag"""
+
+    def get_latest_tag():
+        """"Helper function: Return the latest git tag"""
+
+        git_tag_output = subprocess.check_output(
+            ['git', 'tag', '--list', "v*"]
+            ).decode("utf-8").strip()
+
+        git_tag_list = re.sub('[A-Za-z]', '', git_tag_output).split('\n')
+        git_tag_list.sort(key=lambda s: [int(u) for u in s.split('.')])
+
+        # The latest tag is the last in the list
+        git_tag_latest = git_tag_list[-1]
+
+        return git_tag_latest
+
+    latest_tag = get_latest_tag()
+
+    # Return 'X.Y' from 'X.Y.Z'
+    return latest_tag[:-2]
+
+
+def get_next_stable_version():
+    """Return the next stable version"""
+
+    current_version = get_current_stable_version()
+
+    # Break apart 'x.y' value, increment y and then concatenate into 'x.y' again
+    next_version = "{}.{}".format(
+        int(current_version[:1]),
+        int(current_version[-2:]) + 1
+        )
+
+    return next_version
+
+
+def get_current_commit_hash():
+    """Return commit hash string"""
+
+    # e.g., v8.29.0-98-g07d02c6 (after decoding)
+    # https://stackoverflow.com/questions/2502833/store-output-of-subprocess-popen-call-in-a-string
+    git_describe_output = subprocess.check_output(['git', 'describe']).decode("utf-8")
+
+    # Grab the last portion of the strings, then strip off leading 'g'
+    commit_hash = git_describe_output.split('-')[-1][1:].strip()
+
+    return commit_hash
+
+
+def get_release_string(release_type, version):
+    """Return a release string representing the type of build. Verbose for
+    dev builds and with sparse version info for release builds"""
+
+    if release_type == "dev":
+
+        # Used in dev builds
+        DATE = datetime.date.today()
+        TODAY = DATE.strftime('%Y%m%d')
+
+        release_string = "{}-{}-{}-{}".format(
+            get_next_stable_version(),
+            get_current_branch(),
+            TODAY,
+            get_current_commit_hash()
+            )
+    else:
+        release_string = "{}".format(version)
+
+    return release_string

--- a/source/index.rst
+++ b/source/index.rst
@@ -23,7 +23,7 @@ Manual
 ------
 .. toctree::
    :maxdepth: 2
-   
+
    installation/index
    configuration/index
    containers/index
@@ -34,7 +34,7 @@ Manual
    tutorials/index
    development/index
    historical/index
-   
+
 Reference
 ---------
 .. toctree::
@@ -63,3 +63,7 @@ doesn't require a lot of time - even a single mouse click helps. Learn
 
 .. _Sponsor's Page: http://www.rsyslog.com/sponsors
 
+
+.. only:: dev
+
+    Built on |today| from branch |DOC_BRANCH|, commit |DOC_COMMIT|.


### PR DESCRIPTION
This is intended for use with dev builds of the docs to quickly identify what branch the docs were bult from. This also helps with epub builds as some readers do not always display the "release" details prominently once the file has been opened.

Note: Looks like my editor applied some whitespace trimming when I saved the index file, so the commit isn't entirely "clean".

@rgerhards What do you think? The results should be visible here soon (builds are performed every 15 minutes, takes just under 10 minutes to complete):

http://rsyslog.whyaskwhy.org/display_branch_build_info/
