### PR TITLE
Minor tweaks to Container-Features doc

### DIFF
--- a/source/containers/container_features.rst
+++ b/source/containers/container_features.rst
@@ -5,5 +5,5 @@ Upon start, rsyslog checks if it is running as pid 1. If so, this is
 a clear indication it is running inside a container. This changes
 some parameter defaults:
 
-- ctl-c is enabled
+- :kbd:`Control-C` is enabled
 - no pid file is written

--- a/source/containers/index.rst
+++ b/source/containers/index.rst
@@ -5,7 +5,7 @@ In this chapter, we describe how rsyslog can be used together with
 containers.
 
 All versions of rsyslog work well in containers. Versions beginning with
-8.32.0 have also been made explicitely container-aware and provide some
+8.32.0 have also been made explicitly container-aware and provide some
 extra features that are useful inside containers.
 
 Note: the sources for docker containers created by the rsyslog project
@@ -15,6 +15,6 @@ reports and pull requests are also appreciated for this project.
 
 .. toctree::
    :maxdepth: 2
-   
+
    container_features
    docker_specifics


### PR DESCRIPTION
- Typo fix
- Use 'kbd' Sphinx directive to highlight the specific keystroke used to exit rsyslog
- Add comments noting points for future expansion