### PR TITLE
Add missing newline after literal code marker

### DIFF
--- a/source/configuration/modules/mmrm1stspace.rst
+++ b/source/configuration/modules/mmrm1stspace.rst
@@ -21,6 +21,7 @@ This example receives messages over imtcp and modifies them, before sending
 them to a file.
 
 ::
+
    module(load="imtcp")
    module(load="mmrm1stspace")
    input(type="imtcp" port="13514")


### PR DESCRIPTION
This fixes the display of the config sample as the text is now rendered as a code block instead of raw text:

http://www.rsyslog.com/doc/v8-stable/configuration/modules/mmrm1stspace.html

closes rsyslog/rsyslog-doc#307
