### PR TITLE
Add standard footer

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -72,6 +72,14 @@ rst_prolog = """
 
 """
 
+# http://www.sphinx-doc.org/en/stable/config.html#confval-rst_epilog
+# This will be included at the end of every source file that is read.
+rst_epilog = """
+
+.. include:: /footer.inc.rst
+
+"""
+
 
 
 

--- a/source/footer.inc.rst
+++ b/source/footer.inc.rst
@@ -1,0 +1,16 @@
+
+
+.. seealso::
+
+   If you would like to contribute to these docs, but are unsure where to
+   start, please see the |GitHubDocProjectREADME|_ for an overview of the
+   process. If you would like to contribute to the main source project,
+   please review the contribution guidelines listed in the
+   |GitHubSourceProjectREADME|_.
+
+   If you have a question about these docs or |PRODUCT| in general, please
+   see the following resources:
+
+   - |RsyslogOfficialForums|_
+   - |RsyslogOfficialMailingList|_
+   - GitHub: |GitHubDocProject|_, |GitHubSourceProject|_


### PR DESCRIPTION
> Instead of maintaining the substitution definitions within the Sphinx build configuration file, those definitions have been moved to a separate include file. Accordingly, the build conf has been updated to add an exclude entry for all *.inc.rst files so that they are not included multiple times during build
> processing. This include file is currently referenced by the rst_prolog build conf option.
> 
> A footer has been created and is included by all pages via an include statement within the rst_epilog build conf option. This footer is an attempt to display common "go here for help" options that should be made prominent for newcomers to the project.

@rgerhards What do you think about this idea? For the final merge, I would probably break up the two changes into either separate PRs or separate commits.

This will be the live view once the current build finishes (about 10 minutes after I post this):

http://rsyslog.whyaskwhy.org/standard_footer/
