### PR TITLE
Remove broken footnotes, 'Related Links' section

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -53,20 +53,13 @@ Reference
 Sponsors and Community
 ----------------------
 
-Please visit the rsyslog Sponsor's Page\ [4]_ to honor the project sponsors or 
-become one yourself! We are very grateful for any help towards the project 
+Please visit the rsyslog `Sponsor's Page`_ to honor the project sponsors or
+become one yourself! We are very grateful for any help towards the project
 goals.
-
-Visit the Rsyslog Status Page\ [2]_ to obtain current version information and 
-project status.
 
 If you like rsyslog, you might want to lend us a helping hand. It
 doesn't require a lot of time - even a single mouse click helps. Learn
-:doc:`how to help the rsyslog project <how2help>`.
+:doc:`how2help`.
 
+.. _Sponsor's Page: http://www.rsyslog.com/sponsors
 
-Related Links
--------------
-
-.. [2] `rsyslog Sponsor's Page <http://www.rsyslog.com/sponsors>`_
-.. [4] `Regular expression checker/generator tool for rsyslog <http://www.rsyslog.com/tool-regex>`_


### PR DESCRIPTION
The footnote references were broken and the 'Related Links' section was bare, so I pruned them and moved the Sponsors link just below the 'Sponsors and Community' section intentionally so it stands out.

Once some PRs ahead of this one goes through I plan to move the external link reference to
the substitution definitions file (again, in another PR) since this is probably not the only place we will reference the Sponsors link.

Additionally, I removed the explicit link text for the "How You Can Help" page since the title for that page is used if you do not override it with explicit link text.

The changes should be live here soon:

http://rsyslog.whyaskwhy.org/i502-footnote-fixes/

closes rsyslog/rsyslog-doc#502
