### PR TITLE
document the new 8.33 include() object

### DIFF
--- a/source/rainerscript/configuration_objects.rst
+++ b/source/rainerscript/configuration_objects.rst
@@ -37,3 +37,9 @@ timezone()
 
 The :doc:`timezone <../configuration/timezone>` object is used to define
 timezone settings.
+
+include()
+---------
+
+The :doc:`include <include>`  object is use to include configuration snippets
+stored elsewhere into the configuration.

--- a/source/rainerscript/include.rst
+++ b/source/rainerscript/include.rst
@@ -1,0 +1,56 @@
+The rsyslog include() object
+============================
+
+The include object is use to include configuration snippets
+stored elsewhere into the configuration.
+
+Parameters
+----------
+
+  - file
+
+    Name of file to be included. May include wildcards, in which case all
+    matching files are included (in order of file name sort order).
+
+  - text
+
+    Text to be included. This is most useful when using backtick string
+    constants.
+
+  - mode
+
+    Affects how mising files are to be handled:
+
+    - "abort-if-missing", with rsyslog aborting when the file is not present
+    - "required" *(default)*, with rsyslog emitting an error message but otherwise
+      continuing when the file is not present
+    - "optional", which means non-present files will be skipped without notice
+
+Note: one of the "file" or "text parameters must be specified, but not both.
+
+Example
+-------
+
+To include a file and generate an error message if not present, do::
+
+    include(file="/path/to/include.conf")
+
+To include a file that need not necessarily be present, do::
+
+    include(file="/path/to/include.conf" mode="optional")
+
+To include multiple files, do::
+
+    include(file="/etc/rsyslog.d/*.conf")
+
+To include an environment variable as configuration, do::
+
+    include(text=`echo $ENV_VAR`)
+
+To include a file specified via an environment variable, do::
+
+    include(file=`echo $ENV_VAR`)
+
+To include an file specified via an environment variable, do::
+
+    include(file=`echo $ENV_VAR` mode="optional")

--- a/source/rainerscript/index.rst
+++ b/source/rainerscript/index.rst
@@ -27,3 +27,4 @@ The first full implementation is available since rsyslog v6.
    rainerscript_call
    rainerscript_call_indirect
    global
+   include


### PR DESCRIPTION
The documents the new objects and its properties.

Note that I did deliberately not try to get to a "nice formatting", as
we are currently standardizing on something, and so a change is needed
in any case. Even more so, the whole (Rainer)Script documentation needs
to be restructured. So this patch gives the necessary information on
include(), but does not try to improve the state of the doc by itself.

see also https://github.com/rsyslog/rsyslog/pull/2426