### PR TITLE
Move substitution definitions to include file

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -58,19 +58,21 @@ author = u'Rainer Gerhards and Others'
 # http://www.sphinx-doc.org/en/stable/config.html#confval-rst_prolog
 #
 # This will be included at the beginning of every source file that is read.
+#
+# Note: We intentionally include a few substitution definitions directly
+# so that the placeholders used here can be replaced by Python's
+# string format method.
 rst_prolog = """
-.. |PRODUCT| replace:: ``Rsyslog``
 
 .. |DOC_BUILD| replace:: ``{doc_build}``
 .. |DOC_COMMIT| replace:: ``{doc_commit}``
 .. |DOC_BRANCH| replace:: ``{doc_branch}``
 
-.. |FmtBasicName| replace:: ``basic``
-.. |FmtAdvancedName| replace:: ``advanced``
-.. |FmtObsoleteName| replace:: ``obsolete legacy``
+.. include:: /substitution_definitions.inc.rst
 
-.. |FmtObsoleteDescription| replace:: ``Obsolete Format Equivalents``
 """
+
+
 
 
 
@@ -158,7 +160,12 @@ if version == '8':
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+#
+# Note: We list the *.inc.rst filename pattern here so that matching
+# files will not be parsed as separate files to include directly into
+# the documentation structure in addition to them being pulled in via
+# include statements.
+exclude_patterns = ['*.inc.rst']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/source/substitution_definitions.inc.rst
+++ b/source/substitution_definitions.inc.rst
@@ -1,0 +1,51 @@
+
+..
+  This file is included by the common header file, which is itself
+  included by means of the rst_prolog Sphinx build confiugration
+  file (source/conf.py). Add substitutions here instead of directly to
+  the rst_prolog configuration option.
+
+
+.. |PRODUCT| replace:: ``Rsyslog``
+
+.. |FmtBasicName| replace:: ``basic``
+.. |FmtAdvancedName| replace:: ``advanced``
+.. |FmtObsoleteName| replace:: ``obsolete legacy``
+
+.. |FmtObsoleteDescription| replace:: ``Obsolete Format Equivalents``
+
+
+.. |GitHubDocProject| replace:: rsyslog-doc project
+.. _GitHubDocProject: https://github.com/rsyslog/rsyslog-doc/
+
+.. |GitHubDocProjectREADME| replace:: rsyslog-doc project README
+.. _GitHubDocProjectREADME: https://github.com/rsyslog/rsyslog-doc/blob/master/README.md
+
+.. |GitHubDocProjectDevREADME| replace:: rsyslog-doc project BUILDS README
+.. _GitHubDocProjectDevREADME: https://github.com/rsyslog/rsyslog-doc/blob/master/BUILDS_README.md
+
+.. |GitHubDocProjectGoodFirstIssueLabel| replace:: rsyslog-doc issues marked with Good First Issue label
+.. _GitHubDocProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog-doc/labels/good%20first%20issue
+
+
+.. |GitHubDocProjectHelpWantedLabel| replace:: rsyslog-doc issues marked with Help Wanted label
+.. _GitHubDocProjectHelpWantedLabel: https://github.com/rsyslog/rsyslog-doc/labels/help%20wanted
+
+.. |RsyslogOfficialForums| replace:: Forum
+.. _RsyslogOfficialForums: http://kb.monitorware.com/rsyslog-f40.html
+
+.. |RsyslogOfficialMailingList| replace:: Mailing list
+.. _RsyslogOfficialMailingList: http://lists.adiscon.net/mailman/listinfo/rsyslog
+
+
+.. |GitHubSourceProject| replace:: rsyslog source project
+.. _GitHubSourceProject: https://github.com/rsyslog/rsyslog/
+
+.. |GitHubSourceProjectREADME| replace:: rsyslog project README
+.. _GitHubSourceProjectREADME: https://github.com/rsyslog/rsyslog/blob/master/README.md
+
+.. |GitHubSourceProjectGoodFirstIssueLabel| replace:: rsyslog issues marked with Good First Issue label
+.. _GitHubSourceProjectGoodFirstIssueLabel: https://github.com/rsyslog/rsyslog/labels/good%20first%20issue
+
+.. |GitHubSourceProjectHelpWantedLabel| replace:: rsyslog issues marked with Help Wanted label
+.. _GitHubSourceProjectHelpWantedLabel: https://github.com/rsyslog/rsyslog/labels/help%20wanted


### PR DESCRIPTION
Instead of maintaining the substitution definitions within the Sphinx build configuration file, those definitions have been moved to a separate include file. 

Accordingly, the build conf has been updated to add an exclude entry for all `*.inc.rst` files so that they are not included multiple times during build processing. This include file is currently referenced by the `rst_prolog` build conf option.