### PR TITLE
tooling: initial standard build container definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ source/_build
 .project
 .vscode
 *.pyc
+*.sw?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-sudo: false
-
-language: python
-
-python: "2.7"
+sudo: required
+services: docker
+language: minimal
 
 install:
-  - pip install -r requirements.txt
+  - docker pull rsyslog/rsyslog_doc_gen
 
 script:
-  - sphinx-build -n -W -b html source build
+  - docker run -e SPHINX_EXTRA_OPTS=-q
+        -v "$PWD":/rsyslog-doc -ti
+        rsyslog/rsyslog_doc_gen

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,2 @@
+This directory contains tools primarily of use for maintainers
+or people who want to build the doc (on a schedule).

--- a/tools/buildenv/.dockerignore
+++ b/tools/buildenv/.dockerignore
@@ -1,0 +1,3 @@
+tmp*
+*.tmp
+README.*

--- a/tools/buildenv/Dockerfile
+++ b/tools/buildenv/Dockerfile
@@ -1,0 +1,17 @@
+FROM	alpine:3.7
+LABEL	maintainer rgerhards@adiscon.com
+RUN	apk add --no-cache py-pip git
+RUN	pip install sphinx
+RUN	adduser -s /bin/ash -D rsyslog rsyslog \
+	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+WORKDIR	/home/appliance
+CMD	["build-doc"]
+ENTRYPOINT ["/home/appliance/starter.sh"]
+VOLUME	/rsyslog-doc
+RUN	chmod a+w /rsyslog-doc
+ENV	BRANCH="v8-stable" \
+	FORMAT="html" \
+	STRICT="-n -W"
+COPY	starter.sh ./
+COPY	tools/* ./tools/
+# USER	rsyslog # does currentyl not play with VOLUME -- TODO: fix

--- a/tools/buildenv/README.md
+++ b/tools/buildenv/README.md
@@ -1,0 +1,6 @@
+build:
+
+docker build  -t rsyslog/rsyslog_doc_gen .
+
+where rsyslog/rsyslog_doc_gen is the tag and the location on dockerhub. Obviously,
+you need to use something else if you are not a maintainer of that repository.

--- a/tools/buildenv/starter.sh
+++ b/tools/buildenv/starter.sh
@@ -1,0 +1,9 @@
+#!/bin/ash
+if [ -f tools/$1 ]; then
+	source tools/$1
+else
+	echo "ERROR: command not known: $*"
+	echo
+	source tools/help
+	exit 1
+fi

--- a/tools/buildenv/tools/bash
+++ b/tools/buildenv/tools/bash
@@ -1,0 +1,2 @@
+echo "You are now in Alpine's ash"
+/bin/ash

--- a/tools/buildenv/tools/build-doc
+++ b/tools/buildenv/tools/build-doc
@@ -1,0 +1,22 @@
+if [ ! -e /rsyslog-doc/source ]; then
+	if [ -e /output ]; then
+		source tools/git-clone
+	else
+		echo "ERROR: /rsyslog-doc is either not mounted or does not point to correct path"
+		echo "       and /output is also not present, so we do not know what to do"
+		source tools/help
+		exit 1
+	fi
+fi
+if [ -e /output ]; then
+	export OUTPUT=/output
+else
+	export OUTPUT=build
+fi
+cd /rsyslog-doc
+sphinx-build $STRICT -b $FORMAT $SPHINX_EXTRA_OPTS source $OUTPUT
+RESULT=$?
+# we need to do the chown as we currently cannot select the right user
+# inside the Dockerfile. Once this is solved, this can go away.
+# chown -R rsyslog:rsyslog $OUTPUT - need to do this differently...
+exit $RESULT

--- a/tools/buildenv/tools/git-clone
+++ b/tools/buildenv/tools/git-clone
@@ -1,0 +1,13 @@
+if [ ! -e /rsyslog-doc ]; then
+	echo "ERROR: /rsyslog-doc is either not mounted or does not point to correct path"
+	source tools/help
+	exit 1
+fi
+if [ -e /rsyslog-doc/source ]; then
+	echo "ERROR: /rsyslog-doc contains a source directory, so we cannot clone into it"
+	source tools/help
+	exit 1
+fi
+cd /
+git clone https://github.com/rsyslog/rsyslog-doc
+(cd /rsyslog-doc; git checkout $BRANCH)

--- a/tools/buildenv/tools/help
+++ b/tools/buildenv/tools/help
@@ -1,0 +1,20 @@
+echo 'docker run -v /your/local/path:/rsyslog-doc <container-name> command
+where command is one of:
+build-doc    - generate documentation (currently HTML only)
+help         - display this help message
+bash         - start an interactive shell (<CTL>-d terminates)
+version-info - outputs some information of component used in container
+git-clone    - clone the official rsyslog-doc project into /rsyslog mount
+               this is a quick way to populate /rsyslog, which must be empty before
+
+Environment variables (set with -eVAR=val on docker run):
+FORMAT       - html (default) or another builder format
+STRICT       - options to cause strict sphinx mode (default "-n -W")
+SPHINX_EXTRA_OPTS - provides any option to sphinx the user whiches, e.g. -q for quiet builds
+
+bind mounts (mount with -v/local/path:/container on docker run):
+/output      - output files will be placed here. If not mounted, output will be under
+               /rsyslog-doc/output
+/rsyslog-doc - checked-out rsyslog doc project; if not mounted but /output is, an
+               automatic git clone is done to a temporary volume
+'

--- a/tools/buildenv/tools/version-info
+++ b/tools/buildenv/tools/version-info
@@ -1,0 +1,3 @@
+echo "Versions used inside this container app:"
+
+sphinx-build --version


### PR DESCRIPTION
This is to be extended, but provides a first impression of how
this could be done. It's useful in any case to use during CI, as
it permits to reproduce exact same results in different environments.

To give the container a try, you need a system with docker installed. Then, run
```
$ docker run -v /path/to/rsyslog-doc_home_dir:/rsyslog-doc rsyslog/rsyslog_doc_gen
```
I have uploaded the container image to above docker hub location.