### PR TITLE
cron script: mimic '--version-sort' option for busybox compatibility

### DIFF
--- a/cron_build_all_branches.sh
+++ b/cron_build_all_branches.sh
@@ -36,8 +36,14 @@ get_dev_branches() {
 # The assumption here is that the latest tag == latest stable tag
 get_latest_tag() {
 
+    # Treat periods as field separators
+    # Sort on second "field"
+    # Perform general numerical sort
+    # Apply grep filter to make sure we pull in stable tags only (no '-dev'
+    #   suffixes, etc)
+    # Grab the last tag from the list
     git tag --list 'v*' | \
-        sort --version-sort | \
+        sort -t '.' -k2 -g | \
         grep -Eo '^v[.0-9]+$' | \
         tail -n 1
 


### PR DESCRIPTION
Instead of using the GNU sort utility's "version sort" option, fall back to a combination of options that appear to provide the same effect, but also work well with busybox (used in some docker container images).

refs rsyslog/rsyslog-doc#524
