### PR TITLE
Dockerfile: Change default branch to build from v8-stable to master

### DIFF
--- a/tools/buildenv/Dockerfile
+++ b/tools/buildenv/Dockerfile
@@ -9,7 +9,7 @@ CMD	["build-doc"]
 ENTRYPOINT ["/home/appliance/starter.sh"]
 VOLUME	/rsyslog-doc
 RUN	chmod a+w /rsyslog-doc
-ENV	BRANCH="v8-stable" \
+ENV	BRANCH="master" \
 	FORMAT="html" \
 	STRICT="-n -W"
 COPY	starter.sh ./


### PR DESCRIPTION
I see where you're checking first to make sure that they don't already have a bind mount for a checked out version of the docs. If the docs are found, they're built as-is without changing the checked out branch. If they don't already have a copy of the docs, then a git clone operation occurs, a checkout call and then a build of the checked out branch. That makes sense. You're essentially emulating someone calling `sphinx-build -b html source build` directly against content in the current working directory.

Provided that the docker image is not meant to be dedicated to building the stable version of the docs, I suggest favoring `master` over `v8-stable` as that fallback branch choice is likely to be of greater interest  to someone opting to build the docs on their own.