### PR TITLE
Add Table of Contents to README files

### DIFF
--- a/BUILDS_README.md
+++ b/BUILDS_README.md
@@ -1,3 +1,17 @@
+<!-- TOC START min:1 max:3 link:true update:true -->
+- [rsyslog-doc builds: A guide to building the rsyslog documentation for maintainers and contributors](#rsyslog-doc-builds-a-guide-to-building-the-rsyslog-documentation-for-maintainers-and-contributors)
+  - [Generating release version of the docs](#generating-release-version-of-the-docs)
+    - [Maintainer](#maintainer)
+    - [Contributors](#contributors)
+  - [Generating development builds](#generating-development-builds)
+    - [Obtain docs](#obtain-docs)
+    - [Build from GitHub download](#build-from-github-download-1)
+    - [Build from Git repo](#build-from-git-repo-1)
+
+<!-- TOC END -->
+
+
+
 # rsyslog-doc builds: A guide to building the rsyslog documentation for maintainers and contributors
 
 *Documentation for building the documentation for ...*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<!-- TOC START min:1 max:3 link:true update:true -->
+- [rsyslog-docs](#rsyslog-docs)
+  - [Documentation for the rsyslog project](#documentation-for-the-rsyslog-project)
+  - [Learning the doc tools](#learning-the-doc-tools)
+  - [Contributed Software/Content](#contributed-softwarecontent)
+  - [Dev Team resources](#dev-team-resources)
+  - [Contributing to the docs](#contributing-to-the-docs)
+  - [Requesting feedback/help](#requesting-feedbackhelp)
+  - [Building the documentation](#building-the-documentation)
+    - [Assumptions](#assumptions)
+    - [Prep environment](#prep-environment)
+    - [Generate documentation](#generate-documentation)
+
+<!-- TOC END -->
+
+
+
 # rsyslog-docs
 
 ## Documentation for the rsyslog project


### PR DESCRIPTION
Used Atom Editor + mardown-toc-auto plugin to generate them

https://atom.io/packages/markdown-toc-auto

Even so, it's quite possible to hand-edit the TOC entries should someone wish to note use the editor + plugin.

Thoughts?

Live view:

- https://github.com/deoren/rsyslog-doc/tree/add-readme-toc/README.md
- https://github.com/deoren/rsyslog-doc/blob/add-readme-toc/BUILDS_README.md

If this looks good, I'll followp-up with doing the same for the remaining README files.