### PR TITLE
Attempt to use 'better' theme, fall back to default theme if not available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 
 # Need at least 1.5.1 due to some of the features we are using
 sphinx >=1.5.1
+
+# Preferred theme; integrates well with the official website
+# Note: the docs will build without this theme package present,
+# but it is preferred that it be used over the stock 'default'
+# theme due to the enhancements regarding whitespace
+sphinx-better-theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,6 +14,19 @@
 import os
 import sys
 
+
+# Attempt to import our desired theme. If successful, then we will use that
+# theme to build the docs. If the import attempt fails, we will use the
+# default theme instead.
+try:
+    from better import better_theme_path
+    html_theme_path = [better_theme_path]
+    desired_theme_available = True
+
+except ImportError:
+    desired_theme_available = False
+
+
 # Module for our custom functions. Used with automating automating build info.
 sys.path.append(os.getcwd())
 import conf_helpers
@@ -212,14 +225,35 @@ suppress_warnings = ['epub.unknown_project_files']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+
+# The theme used for building was set earlier based on the results of an
+# import attempt. If the import was successful, our desired theme will be
+# used. If the import failed, the 'default' theme will be used instead.
+# This works around the possibility that our users will fail to read
+# the direction to run `pip install -r requirements.txt` and will instead
+# just install the sphinx package directly (either via pip install sphinx
+# or via their distro packaging system).
+if desired_theme_available:
+    html_theme = 'better'
+else:
+    html_theme = 'default'
+
+#html_theme = 'default'
 #html_theme = 'basic'
 #html_style = 'rsyslog.css'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+if html_theme == 'better':
+    # Enable max width for our chosen theme only
+    html_theme_options = {
+    'inlinecss': ' @media (max-width: 820px) { div.sphinxsidebar { visibility: hidden; } }',
+    }
+
+else:
+    # If our chosen theme is not present, reset the options dictionary
+    html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
This PR is closely related to the discussion from rsyslog/rsyslog-doc#533.

There are two things accomplished with these changes:

1. Explicitly specify in `requirements.txt` that this Sphinx documentation project relies upon (at present), two components:
    1. Sphinx
    1. `better` theme

1. Attempt to *use* the `better` theme, but if not present gracefully fall back (without error messages) to using the default theme used previously.

This PR does not touch the current Dockerfile, but after this PR is merged it could be updated to take advantage of the changes introduced here (such as using `pip install -r requirements.txt` instead of hard-coding specific packages on a `RUN` line).