### PR TITLE
Build: Set 'simple' dev build string as default

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -125,6 +125,17 @@ if version == '8':
         # fill in values that were not specified by a build script.
         release_type = 'dev'
 
+        # Valid options are "simple" and "detailed". "Simple" contains a short
+        # dev build string intended for space constrained display. "Detailed"
+        # contains a much longer dev build string intended for output that is
+        # used for for copyediting/proofreading, where the generated docs may
+        # hang around a while before being disposed of. In that situation,
+        # having detailed build details in the doc are useful to help
+        # differentiate multiple document builds (even from different branches)
+        # from each other.
+        #release_string_detail = 'detailed'
+        release_string_detail = 'simple'
+
         # Some items in the source are wrapped with the ".. only:: TAG_NAME_HERE"
         # Sphinx directive. This directive prevents the wrapped block of markup
         # from being processed unless the specified tag is set. Using this approach
@@ -144,7 +155,10 @@ if version == '8':
         # were generated and from what commit.
         #
         # The full version, including alpha/beta/rc tags.
-        release = conf_helpers.get_release_string(release_type, version)
+        release = conf_helpers.get_release_string(
+            release_type,
+            release_string_detail,
+            version)
 
 
         # Additions that are used by dev builds
@@ -226,7 +240,13 @@ html_theme = 'default'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+if release_type == 'dev':
+
+    html_title = "{} {} docs".format(
+        project,
+        conf_helpers.get_release_string(
+            release_type, release_string_detail, version)
+    )
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -368,6 +388,12 @@ texinfo_documents = [
 
 
 # -- Options for epub output ---------------------------------------------------
+
+# Use detailed build strings for epub format IF this is a dev build
+# and NOT a stable build (which does not use detailed release strings)
+if release_type == 'dev':
+    epub_title = \
+        conf_helpers.get_release_string(release_type, 'detailed', version)
 
 epub_theme = 'epub'
 epub_basename = project

--- a/source/conf_helpers.py
+++ b/source/conf_helpers.py
@@ -88,7 +88,7 @@ def get_current_commit_hash():
     return commit_hash
 
 
-def get_release_string(release_type, version):
+def get_release_string(release_type, release_string_detail, version):
     """Return a release string representing the type of build. Verbose for
     dev builds and with sparse version info for release builds"""
 
@@ -98,12 +98,36 @@ def get_release_string(release_type, version):
         DATE = datetime.date.today()
         TODAY = DATE.strftime('%Y%m%d')
 
-        release_string = "{}-{}-{}-{}".format(
-            get_next_stable_version(),
-            get_current_branch(),
-            TODAY,
-            get_current_commit_hash()
-            )
+        # The detailed release string is too long for the rsyslog.com 'better'
+        # theme and perhaps too long for other themes as well, so we set the
+        # level to 'simple' by default (to be explicit) and
+        # allow overriding by command-line if desired.
+        if release_string_detail == "simple":
+
+            # 'rsyslog' prefix is already set via 'project' variable in conf.py
+            # HASH
+            # 'docs' string suffix is already ...
+            release_string = "{}".format(
+                get_current_commit_hash()
+                )
+        elif release_string_detail == "detailed":
+
+            # The verbose variation of the release string. This was previously
+            # the default when using the 'classic' theme, but proves to be
+            # too long when viewed using alternate themes. If requested
+            # via command-line override this format is used.
+            release_string = "{}-{}-{}-{}".format(
+                get_next_stable_version(),
+                get_current_branch(),
+                TODAY,
+                get_current_commit_hash()
+                )
+        else:
+            # This means that someone set a value that we do not
+            # have a format defined for. Return an error string instead
+            # to help make it clear what happened.
+            release_string = "invalid value for release_string_detail"
+
     else:
         release_string = "{}".format(version)
 


### PR DESCRIPTION
## Previous default build string

Prior hard-coded dev build string:

  `rsyslog 8.xx-BRANCH-YYYYMMDD-commit_hash documentation`

That format has been given a name of 'detailed'. 

## New default build string

A new simpler format has been defined as:

  `rsyslog commit_hash docs`

## Stable releases

Stable release build strings still use the format of:

  `rsyslog 8.x.x documentation`

## epub format

As before, epub release builds default to the release build strings. epub dev builds still use the detailed release string format. This is because the display of epub files is not affected in the same way as HTML output using themes that are more narrowly restricted in horizontal space.

## How to test

*Assuming you already have Python and Sphinx installed ...*

1. git clone https://github.com/deoren/rsyslog-doc rsyslog-doc-testing
1. cd rsyslog-doc-testing
1. git checkout i537-short-dev-build-release-string
1. sphinx-build -b html source build
1. sphinx-build -b epub source build
1. firefox build/index.html


## Example output

Live view:

- http://rsyslog.whyaskwhy.org/i537-short-dev-build-release-string/
- http://rsyslog.whyaskwhy.org/i537-short-dev-build-release-string/rsyslog.epub

I've rebased since that build completed (fixed some doc comments), so the commit hashes won't match up if you compare them. When the next build completes they should match up then.

closes rsyslog/rsyslog#537