### PR TITLE
container: fix quoted parameter passing to container build

### DIFF
--- a/tools/buildenv/Dockerfile
+++ b/tools/buildenv/Dockerfile
@@ -14,4 +14,3 @@ ENV	BRANCH="master" \
 	STRICT="-n -W"
 COPY	starter.sh ./
 COPY	tools/* ./tools/
-# USER	rsyslog # does currentyl not play with VOLUME -- TODO: fix

--- a/tools/buildenv/README.md
+++ b/tools/buildenv/README.md
@@ -4,3 +4,6 @@ docker build  -t rsyslog/rsyslog_doc_gen .
 
 where rsyslog/rsyslog_doc_gen is the tag and the location on dockerhub. Obviously,
 you need to use something else if you are not a maintainer of that repository.
+
+ENV VARS
+DEBUG - turn on some (minimal) container debugging

--- a/tools/buildenv/starter.sh
+++ b/tools/buildenv/starter.sh
@@ -1,4 +1,9 @@
 #!/bin/ash
+if [ "$DEBUG" == "on" ]; then
+	echo "container in debug mode, environment is: "
+	env
+	set -x
+fi
 if [ -f tools/$1 ]; then
 	source tools/$1
 else

--- a/tools/buildenv/tools/build-doc
+++ b/tools/buildenv/tools/build-doc
@@ -14,6 +14,9 @@ else
 	export OUTPUT=build
 fi
 cd /rsyslog-doc
+if [ -e SPHINX_EXTRA_OPTS ]; then
+	export SPHINX_EXTRA_OPTS="$SPHINX_EXTRA_OPTS `cat SPHINX_EXTRA_OPTS`"
+fi
 eval sphinx-build $STRICT -b $FORMAT $SPHINX_EXTRA_OPTS source $OUTPUT
 RESULT=$?
 # we need to do the chown as we currently cannot select the right user

--- a/tools/buildenv/tools/build-doc
+++ b/tools/buildenv/tools/build-doc
@@ -14,7 +14,7 @@ else
 	export OUTPUT=build
 fi
 cd /rsyslog-doc
-sphinx-build $STRICT -b $FORMAT $SPHINX_EXTRA_OPTS source $OUTPUT
+eval sphinx-build $STRICT -b $FORMAT $SPHINX_EXTRA_OPTS source $OUTPUT
 RESULT=$?
 # we need to do the chown as we currently cannot select the right user
 # inside the Dockerfile. Once this is solved, this can go away.

--- a/tools/buildenv/tools/help
+++ b/tools/buildenv/tools/help
@@ -11,6 +11,7 @@ Environment variables (set with -eVAR=val on docker run):
 FORMAT       - html (default) or another builder format
 STRICT       - options to cause strict sphinx mode (default "-n -W")
 SPHINX_EXTRA_OPTS - provides any option to sphinx the user whiches, e.g. -q for quiet builds
+DEBUG         - set to "on" to turn on some minimal container debugging
 
 bind mounts (mount with -v/local/path:/container on docker run):
 /output      - output files will be placed here. If not mounted, output will be under

--- a/tools/buildenv/tools/help
+++ b/tools/buildenv/tools/help
@@ -10,12 +10,19 @@ git-clone    - clone the official rsyslog-doc project into /rsyslog mount
 Environment variables (set with -eVAR=val on docker run):
 FORMAT       - html (default) or another builder format
 STRICT       - options to cause strict sphinx mode (default "-n -W")
+DEBUG        - set to "on" to turn on some minimal container debugging
 SPHINX_EXTRA_OPTS - provides any option to sphinx the user whiches, e.g. -q for quiet builds
-DEBUG         - set to "on" to turn on some minimal container debugging
 
 bind mounts (mount with -v/local/path:/container on docker run):
 /output      - output files will be placed here. If not mounted, output will be under
                /rsyslog-doc/output
 /rsyslog-doc - checked-out rsyslog doc project; if not mounted but /output is, an
                automatic git clone is done to a temporary volume
+
+An alternate way to specify extra options is by adding them, one per line, to the
+SPHINX_EXTRA_OPTS file. The name must be exactly as given, and it must be stored in
+the doc project home directory. This method is especially useful for complex options
+which otherwise might be hard to escape so that the shell does not misinterpret them.
+If both the file SPHINX_EXTRA_OPTS and the environment variable SPHINX_EXTRA_OPTS are
+given, both are used.
 '


### PR DESCRIPTION
PR now contains a bit more, see individual commits. Still think all of these features make sense together, and sparing time to do separate PRs (that would need to build on each other).