### PR TITLE
Clarify that string constants are set at startup

### DIFF
--- a/source/rainerscript/constant_strings.rst
+++ b/source/rainerscript/constant_strings.rst
@@ -1,8 +1,9 @@
 String Constants
 ================
 
-String constants are necessary in any scripting language. The provide
-values that never change during rsyslog's run.
+String constants are necessary in any scripting language. They provide
+values that are evaluated at startup and never change during rsyslog's
+run.
 
 Uses
 ----


### PR DESCRIPTION
Small clarification as suggested by @davidelang.

- refs rsyslog/rsyslog-doc#512
- closes rsyslog/rsyslog-doc#544
