### PR TITLE
Update subst refs, language tweaks, misc fixes

### DIFF
--- a/source/includes/container_dev_env.inc.rst
+++ b/source/includes/container_dev_env.inc.rst
@@ -1,8 +1,13 @@
 .. note::
 
-   The rsyslog project maintains
-   `rsyslog docker development environment images <https://hub.docker.com/u/rsyslog/>`_.
-   They are ready to go for the build. We recommend them over you own build
-   environment - but you need to make sure it's the same distro/version
-   if you want to copy the binary. Rsyslog docker development images
-   are named `rsyslog_dev_` followed by the distro name.
+   The rsyslog project maintains multiple rsyslog docker development
+   environment images at the |RsyslogDockerHub|_. These images have been
+   configured specifically for use with rsyslog and are recommended
+   over your own build environment. Rsyslog docker development images are
+   named with the ``rsyslog_dev_`` prefix, followed by the distro name.
+
+.. warning::
+
+   If you plan to copy the binary for use outside of the container you need
+   to make sure to use an image of the same distro/version when building
+   rsyslog.

--- a/source/includes/container_dev_env.inc.rst
+++ b/source/includes/container_dev_env.inc.rst
@@ -1,10 +1,11 @@
 .. note::
 
-   The rsyslog project maintains multiple rsyslog docker development
-   environment images at the |RsyslogDockerHub|_. These images have been
-   configured specifically for use with rsyslog and are recommended
-   over your own build environment. Rsyslog docker development images are
-   named with the ``rsyslog_dev_`` prefix, followed by the distro name.
+   The rsyslog project maintains multiple `rsyslog docker development
+   environment images <https://hub.docker.com/u/rsyslog/>`_. These
+   images have been configured specifically for use with rsyslog and are
+   recommended over your own build environment. Rsyslog docker development
+   images are named with the ``rsyslog_dev_`` prefix, followed by the
+   distro name.
 
 .. warning::
 

--- a/source/includes/substitution_definitions.inc.rst
+++ b/source/includes/substitution_definitions.inc.rst
@@ -12,12 +12,23 @@
 .. |FmtAdvancedName| replace:: ``advanced``
 .. |FmtObsoleteName| replace:: ``obsolete legacy``
 
-.. |DockerHubURL| replace:: https://hub.docker.com/u/rsyslog/
+.. |FmtObsoleteDescription| replace:: ``Obsolete Format Equivalents``
+
+.. |RsyslogDockerHub| replace:: official rsyslog Docker Hub
+.. _RsyslogDockerHub: https://hub.docker.com/u/rsyslog/
+
+.. |GitHubDockerProject| replace:: rsyslog-docker project
+.. _GitHubDockerProject: https://github.com/rsyslog/rsyslog-docker
+
+.. |DockerApplianceAlpineDockerHubRepo| replace:: Alpine rsyslog appliance Docker Hub repo
+.. _DockerApplianceAlpineDockerHubRepo: https://hub.docker.com/r/rsyslog/syslog_appliance_alpine/
+
 .. |DockerApplianceAlpineName| replace:: ``rsyslog/syslog_appliance_alpine``
 .. |DockerApplianceAlpineRUN| replace:: ``docker run -ti rsyslog/syslog_appliance_alpine``
 
-.. |FmtObsoleteDescription| replace:: ``Obsolete Format Equivalents``
 
+.. |RsyslogPackageDownloads| replace:: rsyslog package downloads
+.. _RsyslogPackageDownloads: http://www.rsyslog.com/downloads/download-other/
 
 .. |GitHubDocProject| replace:: rsyslog-doc project
 .. _GitHubDocProject: https://github.com/rsyslog/rsyslog-doc/

--- a/source/installation/install_from_source.rst
+++ b/source/installation/install_from_source.rst
@@ -3,7 +3,7 @@ Installing rsyslog from Source
 
 *Written by* `Rainer Gerhards <http://www.adiscon.com/en/people/rainer-gerhards.php>`_
 
-**In this paper, I describe how to install** 
+**In this paper, I describe how to install**
 `rsyslog <http://www.rsyslog.com/>`_. It is intentionally a brief
 step-by-step guide, targeted to those who want to quickly get it up and
 running. For more elaborate information, please consult the rest of the
@@ -12,10 +12,10 @@ running. For more elaborate information, please consult the rest of the
 How to make your life easier...
 -------------------------------
 
-There are :doc:`packages for rsyslog <packages>` available.
-If you use them, you can spare yourself many of the steps below.
-This is highly recommended if there is a package for your distribution
-available.
+In addition to building from source, you can also install |PRODUCT|
+using packages. If you use them, you can spare yourself many of the steps
+below. This is highly recommended if there is a package for your
+distribution available. See :doc:`packages` for instructions.
 
 Steps To Do
 -----------
@@ -25,8 +25,7 @@ Step 1 - Download Software
 
 For obvious reasons, you need to download rsyslog. Here, I assume that
 you use a distribution tarball. If you would like to use a version
-directly from the repository, see `build rsyslog from
-repository <build_from_repo.html>`_ instead.
+directly from the repository, see :doc:`build_from_repo` instead.
 
 Load the most recent build from
 `http://www.rsyslog.com/downloads <http://www.rsyslog.com/downloads>`_.
@@ -62,7 +61,7 @@ system:
 * libuuid (usually *uuid-dev*, if not present use --disable-uuid)
 * libgcrypt (usually *libgcrypt-dev*)
 
-Also, development versions of the following supporting libraries 
+Also, development versions of the following supporting libraries
 that the rsyslog project provides are necessary:
 
 * liblogging (only stdlog component is hard requirement)
@@ -135,22 +134,27 @@ you are upgrading from stock syslogd, /etc/syslog.conf is probably a
 good starting point. Rsyslogd understands stock syslogd syntax, so you
 can simply copy over /etc/syslog.conf to /etc/rsyslog.conf. Note since
 version 3 rsyslog requires to load plug-in modules to perform useful
-work (more about `compatibility notes v3 <v3compatibility.html>`_). To
-load the most common plug-ins, add the following to the top of
+work.
+
+.. seealso::
+
+   :doc:`/compatibility/v3compatibility`
+
+To load the most common plug-ins, add the following to the top of
 rsyslog.conf:
 
 ::
 
- $ModLoad immark # provides --MARK-- message capability
- $ModLoad imudp # provides UDP syslog reception
- $ModLoad imtcp # provides TCP syslog reception
- $ModLoad imuxsock # provides support for local system logging
- $ModLoad imklog # provides kernel logging support
+  $ModLoad immark # provides --MARK-- message capability
+  $ModLoad imudp # provides UDP syslog reception
+  $ModLoad imtcp # provides TCP syslog reception
+  $ModLoad imuxsock # provides support for local system logging
+  $ModLoad imklog # provides kernel logging support
 
 Change rsyslog.conf for any further enhancements you would like to see.
 For example, you can add database writing as outlined in the paper
-"`Writing syslog Data to MySQL <rsyslog_mysql.html>`_\ " (remember you
-need to enable MySQL support during step 2 if you want to do that!).
+:doc:`/tutorials/database` (remember you need to enable MySQL
+support during step 2 if you want to do that!).
 
 Step 6 - Disable stock syslogd
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -232,36 +236,3 @@ don't go smooth. In some rare cases, enabling debug logging (-d option)
 in rsyslogd can be helpful. If all fails, go to
 `www.rsyslog.com <http://www.rsyslog.com>`_ and check the forum or
 mailing list for help with your issue.
-
-Housekeeping stuff
-------------------
-
-This section and its subsections contain all these nice things that you
-usually need to read only if you are really curios ;)
-
-Feedback requested
-~~~~~~~~~~~~~~~~~~
-
-I would appreciate feedback on this tutorial.
-Additional ideas, comments or bug sighting reports are very
-welcome. Please `let me know <mailto:rgerhards@adiscon.com>`_ about
-them.
-
-Revision History
-~~~~~~~~~~~~~~~~
-
--  2005-08-08 \* `Rainer Gerhards`_ \*
-   Initial version created
--  2005-08-09 \* `Rainer Gerhards`_ \*
-   updated to include distro-specific directories, which are now
-   mandatory
--  2005-09-06 \* `Rainer Gerhards`_ \*
-   added information on log rotation scripts
--  2007-07-13 \* `Rainer Gerhards`_ \*
-   updated to new autotools-based build system
--  2008-10-01 \* `Rainer Gerhards`_ \*
-   added info on building from source repository
--  2014-03181 \* `Rainer
-   Gerhards <http://www.adiscon.com/en/people/rainer-gerhards.php>`_  \*
-   revamped doc to match current state.
-

--- a/source/installation/packages.rst
+++ b/source/installation/packages.rst
@@ -21,12 +21,17 @@ can help with simple config questions, for anything else we concentrate on
 current versions.
 
 The rsyslog project offers current packages for a number of major distributions.
-More information about these can be found at http://www.rsyslog.com/downloads/download-other/.
+More information about these can be found at the |RsyslogPackageDownloads|_
+page.
 
 If you do not find a suitable package for your distribution, there is no
-reason to panic. You can use the :doc:`rsyslog docker containers <rsyslog_docker>`
-instead or
-:doc:`install rsyslog from the source tarball <install_from_source>`.
+reason to panic. You can use official rsyslog docker containers or
+install rsyslog from the source tarball.
+
+.. seealso::
+
+   - :doc:`rsyslog_docker`
+   - :doc:`install_from_source`
 
 Package Structure
 -----------------
@@ -57,4 +62,4 @@ Contributing
 additional distribution and know how to build packages, please consider
 contributing to the project and joining the packaging team. Also, rsyslog's
 presence on github also contains the sources for the currently
-maintained packages. They can be found at https://github.com/rsyslog.
+maintained packages. They can be found at the |GitHubSourceProject|_.

--- a/source/installation/rsyslog_docker.rst
+++ b/source/installation/rsyslog_docker.rst
@@ -6,8 +6,8 @@ all rsyslog features in an easy to use way. To run it, simply do
 
 |DockerApplianceAlpineRun|
 
-Up-to-date information on how to use this container can be found at
-Dockerhub: https://hub.docker.com/r/rsyslog/syslog_appliance_alpine/.
+Up-to-date information on how to use this container can be found at the
+|DockerApplianceAlpineDockerHubRepo|_.
 
 .. warning::
 
@@ -16,8 +16,8 @@ Dockerhub: https://hub.docker.com/r/rsyslog/syslog_appliance_alpine/.
 
 Further Information
 -------------------
-The rsyslog project provides a number of different containers for
+The rsyslog project also provides a number of additional containers for
 different needs (end users, developers, package builders, ...). A full
-overview of what is currently available can be found at |DockerHubURL|.
-Source code for the docker containers is kept in Github:
-https://github.com/rsyslog/rsyslog-docker
+overview of what is currently available can be found at the |RsyslogDockerHub|_.
+Source code for the docker containers is kept in Github at
+|GitHubDockerProject|_.


### PR DESCRIPTION
What started as a focused effort turned into me wandering around some related docs and tweaking various items, creating new substitution references, fixing some old HTML doc page references and performing some general cleanup.

- Loosely related to rsyslog/rsyslog-doc#525
- refs rsyslog/rsyslog-doc#452 (a few hard-coded references were fixed here)

@rgerhards Any concerns with this PR?