### PR TITLE
fix docker container: contained rsyslog.com site theme

### DIFF
--- a/tools/buildenv/Dockerfile
+++ b/tools/buildenv/Dockerfile
@@ -1,7 +1,7 @@
 FROM	alpine:3.7
 LABEL	maintainer rgerhards@adiscon.com
 RUN	apk add --no-cache py-pip git
-RUN	pip install sphinx sphinx-better-theme
+RUN	pip install sphinx
 RUN	adduser -s /bin/ash -D rsyslog rsyslog \
 	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 WORKDIR	/home/appliance


### PR DESCRIPTION
The docker container is for the rsyslog-doc project, and should be
agnostic to its users. So it was a bad idea in the first place to
put a website-only dependency into the container. Now removing that.

see also https://github.com/rsyslog/rsyslog-doc/pull/543#issuecomment-364761077