### PR TITLE
imuxsock: change false heading

### DIFF
--- a/source/configuration/modules/imuxsock.rst
+++ b/source/configuration/modules/imuxsock.rst
@@ -38,7 +38,7 @@ Configuration Parameters
 
    Parameter names are case-insensitive.
 
-Global Parameters
+Module Parameters
 -----------------
 
 .. warning::


### PR DESCRIPTION
The heading for the module parameter was named global parameter.