### PR TITLE
Add doc-specific label refs for stats section

### DIFF
--- a/source/configuration/modules/impstats.rst
+++ b/source/configuration/modules/impstats.rst
@@ -46,7 +46,7 @@ continuously being added, and older versions do not support everything.
 Notable Features
 ================
 
-- :ref:`statistic-counter`
+- :ref:`impstats-statistic-counter`
 
 
 
@@ -276,7 +276,7 @@ restart). Note that such lower bound logic requires *resetCounters*
 to be set to off.
 
 
-.. _statistic-counter:
+.. _impstats-statistic-counter:
 
 Statistic Counter
 =================
@@ -325,7 +325,7 @@ in 10 minute intervals:
    module(load="impstats"
           interval="600"
           severity="7")
- 
+
    # to actually gather the data:
    syslog.=debug /var/log/rsyslog-stats
 
@@ -342,7 +342,7 @@ data is NOT emitted to the syslog stream but to a local file instead.
           interval="600"
           severity="7"
           log.syslog="off"
-          # need to turn log stream logging off! 
+          # need to turn log stream logging off!
           log.file="/path/to/local/stats.log")
 
 

--- a/source/configuration/modules/imptcp.rst
+++ b/source/configuration/modules/imptcp.rst
@@ -24,7 +24,7 @@ can be used.
 Notable Features
 ================
 
-- :ref:`statistic-counter`
+- :ref:`imptcp-statistic-counter`
 - :ref:`error-messages`
 
 
@@ -525,7 +525,7 @@ Experimental parameter which caues rsyslog to recognise a new message
 only if the line feed is followed by a '<' or if there are no more characters.
 
 
-.. _statistic-counter:
+.. _imptcp-statistic-counter:
 
 Statistic Counter
 =================

--- a/source/configuration/modules/imrelp.rst
+++ b/source/configuration/modules/imrelp.rst
@@ -33,7 +33,7 @@ Clients send messages to the RELP server via omrelp.
 Notable Features
 ================
 
-- :ref:`statistic-counter`
+- :ref:`imrelp-statistic-counter`
 
 
 Configuration Parameters
@@ -328,7 +328,7 @@ This has only effect if keep-alive is enabled. The functionality may
 not be available on all platforms.
 
 
-.. _statistic-counter:
+.. _imrelp-statistic-counter:
 
 Statistic Counter
 =================


### PR DESCRIPTION
Duplicate labels made it past CI builds (due to each PR being separate and not rebased on master from prior merges). This commit introduces a module-specific prefix for the labels
in order to prevent conflicts.

refs #573, #574, #575