### PR TITLE
imfile: Clarify behavior of Tag parameter

### DIFF
--- a/source/configuration/modules/imfile.rst
+++ b/source/configuration/modules/imfile.rst
@@ -212,9 +212,9 @@ Tag
 
    "string", "none", "yes", "``$InputFileTag``"
 
-The tag to be used for messages that originate from this file. If
-you would like to see the colon after the tag, you need to specify it
-here (like 'tag="myTagValue:"').
+The tag to be assigned to messages read from this file. If you would like to
+see the colon after the tag, you need to include it when you assign a tag
+value, like so: ``tag="myTagValue:"``.
 
 
 Facility


### PR DESCRIPTION
The previous wording was found to be confusing in comparison with how the Facility and Severity parameters are described. Here similar emphasis has been added to stress that the
tag is set for messages read from the file.

closes rsyslog/rsyslog-doc#582
