### PR TITLE
imfile: Update facility and severity parameters

### DIFF
--- a/source/configuration/modules/imfile.rst
+++ b/source/configuration/modules/imfile.rst
@@ -225,11 +225,15 @@ Facility
    :widths: auto
    :class: parameter-table
 
-   "facility", "128", "no", "``$InputFileFacility``"
+   "integer or string (preferred)", "local0", "no", "``$InputFileFacility``"
 
-The syslog facility to be assigned to lines read. Can be specified
-in textual form (e.g. "local0", "local1", ...) or as numbers (e.g.
-16 for "local0"). Textual form is suggested. Default  is "local0".
+The syslog facility to be assigned to messages read from this file. Can be
+specified in textual form (e.g. ``local0``, ``local1``, ...) or as numbers (e.g.
+16 for ``local0``). Textual form is suggested. Default  is ``local0``.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog
 
 
 Severity
@@ -240,11 +244,15 @@ Severity
    :widths: auto
    :class: parameter-table
 
-   "severity", "5", "no", "``$InputFileSeverity``"
+   "integer or string (preferred)", "notice", "no", "``$InputFileSeverity``"
 
 The syslog severity to be assigned to lines read. Can be specified
-in textual   form (e.g. "info", "warning", ...) or as numbers (e.g. 6
-for "info"). Textual form is suggested. Default is "notice".
+in textual   form (e.g. ``info``, ``warning``, ...) or as numbers (e.g. 6
+for ``info``). Textual form is suggested. Default is ``notice``.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog
 
 
 PersistStateInterval


### PR DESCRIPTION
- Note that the type is integer or string, with string values preferred

- Emphasized that both severity and facility are applied to messages
  read from the specified file (previously emphasized "lines read")

- Add "see also" for additional Facility and Severity info
  by way of Wikipedia Syslog page

- Update default column in both tables to use textual version
    - corrected default for Facility parameter

closes rsyslog/rsyslog-doc#583