### PR TITLE
Fix reference to ActionForwardDefaultTemplate in omfwd.rst

### DIFF
--- a/source/configuration/modules/omfwd.rst
+++ b/source/configuration/modules/omfwd.rst
@@ -334,7 +334,7 @@ Legacy Configuration Parameters
 
 Note: parameter names are case-insensitive.
 
--  **$ActionForwardDefaultTemplateName**\ string [templatename]
+-  **$ActionForwardDefaultTemplate**\ string [templatename]
    sets a new default template for UDP and plain TCP forwarding action
 -  **$ActionSendTCPRebindInterval**\ integer
    instructs the TCP send action to close and re-open the connection to


### PR DESCRIPTION
Used to say "ActionForwardDefaultTemplateName". Which does not work.
Now it agrees with: http://www.rsyslog.com/doc/v8-stable/configuration/action/index.html