### PR TITLE
Fix SysSock.Name parameter type

### DIFF
--- a/source/configuration/modules/imuxsock.rst
+++ b/source/configuration/modules/imuxsock.rst
@@ -119,7 +119,7 @@ SysSock.Name
    :widths: auto
    :class: parameter-table
 
-   "string", "/dev/log", "no", "``$SystemLogSocketName``"
+   "word", "/dev/log", "no", "``$SystemLogSocketName``"
 
 Specifies an alternate log socket to be used instead of the default system
 log socket, traditionally ``/dev/log``. Unless disabled by the


### PR DESCRIPTION
The type for this parameter was mislabeled. This commit changes the type to match the type specified in the [source file](https://github.com/rsyslog/rsyslog/blob/a11719a3bcae526d016a7d71d2d791692d187422/plugins/imuxsock/imuxsock.c#L257
):

```c
	{ "syssock.name", eCmdHdlrGetWord, 0 },
```
Credit: @PascalWithopf for setting me straight on the specific types supported and where to find/confirm those values.