### PR TITLE
use different method to obtain commit hash

### DIFF
--- a/source/conf_helpers.py
+++ b/source/conf_helpers.py
@@ -78,12 +78,7 @@ def get_next_stable_version():
 def get_current_commit_hash():
     """Return commit hash string"""
 
-    # e.g., v8.29.0-98-g07d02c6 (after decoding)
-    # https://stackoverflow.com/questions/2502833/store-output-of-subprocess-popen-call-in-a-string
-    git_describe_output = subprocess.check_output(['git', 'describe']).decode("utf-8")
-
-    # Grab the last portion of the strings, then strip off leading 'g'
-    commit_hash = git_describe_output.split('-')[-1][1:].strip()
+    commit_hash = subprocess.check_output(['git', 'log', "--pretty=format:'%h'", 'HEAD', '-n1']).decode("utf-8")
 
     return commit_hash
 


### PR DESCRIPTION
Most importantly, Travis CI stopped working with the old method
on 2018-04-10. In any case, the new method looks more up to the
point