### PR TITLE
imklog.rst: fix typo in parameter name

### DIFF
--- a/source/configuration/modules/imklog.rst
+++ b/source/configuration/modules/imklog.rst
@@ -47,7 +47,7 @@ is needed for good reason. Bottom line: if you don't have a good idea
 why you should use this setting, do not touch it.
 
 
-PermitNonKernalFacility
+PermitNonKernelFacility
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::


### PR DESCRIPTION
`PermitNonKernalFacility` -> `PermitNonKernelFacility`

I copied the parameter from documentation and got error, until I fixed the typo. I even created https://github.com/rsyslog/rsyslog/issues/2685 before I recognized the typo :)