### PR TITLE
pmnormalize: rewrite documentation

### DIFF
--- a/source/configuration/modules/idx_parser.rst
+++ b/source/configuration/modules/idx_parser.rst
@@ -10,6 +10,7 @@ The current modules are currently provided as part of rsyslog:
 
 .. toctree::
    :glob:
+   :maxdepth: 1
 
    pm*
 

--- a/source/configuration/modules/pmnormalize.rst
+++ b/source/configuration/modules/pmnormalize.rst
@@ -1,91 +1,121 @@
+*****************************************************
 Log Message Normalization Parser Module (pmnormalize)
-=====================================================
+*****************************************************
 
-**Module Name:    pmnormalize**
+===========================  ===========================================================================
+**Module Name:**             **pmnormalize**
+**Author:**                  Pascal Withopf <pascalwithopf1@gmail.com>
+**Available since:**         8.27.0
+===========================  ===========================================================================
 
-**Available since:** 8.27.0
 
-**Author:** Pascal Withopf <pascalwithopf1@gmail.com>
-
-**Description**:
+Purpose
+=======
 
 This parser normalizes messages with the specified rules and populates the
 properties for further use.
 
+
+Configuration Parameters
+========================
+
+.. note::
+
+   Parameter names are case-insensitive.
+
+
 Action Parameters
-~~~~~~~~~~~~~~~~~
+-----------------
 
-Note: parameter names are case-insensitive.
+Rulebase
+^^^^^^^^
 
-.. function:: rulebase <word>
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
 
-   Specifies which rulebase file is to use. If there are multiple
-   pmnormalize instances, each one can use a different file. However, a
-   single instance can use only a single file. This parameter or **rule**
-   MUST be given, because normalization can only happen based on a rulebase.
-   It is recommended that an absolute path name is given. Information on
-   how to create the rulebase can be found in the `liblognorm
-   manual <http://www.liblognorm.com/files/manual/index.html>`_.
+   "word", "none", "no", "none"
 
-.. function:: rule <array>
-
-   Contains an array of strings which will be put together as the rulebase.
-   This parameter or **rulebase** MUST be given, because normalization can
-   only happen based on a rulebase.
-
-.. function:: undefinedpropertyerror <on/off>
-
-   **Default: off**
-
-   With this parameter an error message is controlled, which will be put out
-   every time pmnormalize can't normalize a message.
-
-See Also
-~~~~~~~~
+Specifies which rulebase file is to use. If there are multiple
+pmnormalize instances, each one can use a different file. However, a
+single instance can use only a single file. This parameter or **rule**
+MUST be given, because normalization can only happen based on a rulebase.
+It is recommended that an absolute path name is given. Information on
+how to create the rulebase can be found in the `liblognorm
+manual <http://www.liblognorm.com/files/manual/index.html>`_.
 
 
-Caveats/Known Bugs
-~~~~~~~~~~~~~~~~~~
+Rule
+^^^^
 
-None known at this time.
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
 
-Example
-~~~~~~~
+   "array", "none", "no", "none"
 
-**Sample 1:**
+Contains an array of strings which will be put together as the rulebase.
+This parameter or **rulebase** MUST be given, because normalization can
+only happen based on a rulebase.
+
+
+UndefinedPropertyError
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+With this parameter an error message is controlled, which will be put out
+every time pmnormalize can't normalize a message.
+
+
+Examples
+========
+
+Normalize msgs received via imtcp
+---------------------------------
 
 In this sample messages are received via imtcp. Then they are normalized with
 the given rulebase and written to a file.
 
-::
+.. code-block:: none
 
-  module(load="imtcp")
-  module(load="pmnormalize")
+   module(load="imtcp")
+   module(load="pmnormalize")
 
-  input(type="imtcp" port="13514" ruleset="ruleset")
+   input(type="imtcp" port="13514" ruleset="ruleset")
 
-  parser(name="custom.pmnormalize" type="pmnormalize" rulebase="/tmp/rules.rulebase")
+   parser(name="custom.pmnormalize" type="pmnormalize" rulebase="/tmp/rules.rulebase")
 
-  ruleset(name="ruleset" parser="custom.pmnormalize") {
-  	action(type="omfile" file="/tmp/output")
-  }
+   ruleset(name="ruleset" parser="custom.pmnormalize") {
+   	action(type="omfile" file="/tmp/output")
+   }
 
-**Sample 2:**
+
+Write normalized messages to file
+---------------------------------
 
 In this sample messages are received via imtcp. Then they are normalized with
 the given rule array. After that they are written in a file.
 
-::
+.. code-block:: none
 
-  module(load="imtcp")
-  module(load="pmnormalize")
+   module(load="imtcp")
+   module(load="pmnormalize")
 
-  input(type="imtcp" port="10514" ruleset="outp")
+   input(type="imtcp" port="10514" ruleset="outp")
 
-  parser(name="custom.pmnormalize" type="pmnormalize" rule=[
-  		"rule=:<%pri:number%> %fromhost-ip:ipv4% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%",
-  		"rule=:<%pri:number%> %hostname:word% %fromhost-ip:ipv4% %syslogtag:char-to:\\x3a%: %msg:rest%"])
+   parser(name="custom.pmnormalize" type="pmnormalize" rule=[
+   		"rule=:<%pri:number%> %fromhost-ip:ipv4% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%",
+   		"rule=:<%pri:number%> %hostname:word% %fromhost-ip:ipv4% %syslogtag:char-to:\\x3a%: %msg:rest%"])
 
-  ruleset(name="outp" parser="custom.pmnormalize") {
-  	action(type="omfile" File="/tmp/output")
-  }
+   ruleset(name="outp" parser="custom.pmnormalize") {
+   	action(type="omfile" File="/tmp/output")
+   }
+


### PR DESCRIPTION
Module documentation was rewritten.
Depth of the list in the parser index page decreased
for better overview