### PR TITLE
Added allowed_error_codes documentation

### DIFF
--- a/source/configuration/modules/ommongodb.rst
+++ b/source/configuration/modules/ommongodb.rst
@@ -90,6 +90,20 @@ Collection
 Collection to use.
 
 
+Allowed_Error_Codes
+^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "array", "no", "no", "none"
+
+The list of error codes returned by MongoDB you want ommongodb to ignore.
+Please use the following format: allowed_error_codes=["11000","47"].
+
+
 Template
 ^^^^^^^^
 


### PR DESCRIPTION
closes #636 

I could not update the branch mentioned in #636, so I create this merge PR here. I needed to update the original PR because error codes now use array mode config parameter (which is meant for such use cases).