### PR TITLE
fix pod_name field match in filename rule - everything up to _

### DIFF
--- a/source/configuration/modules/mmkubernetes.rst
+++ b/source/configuration/modules/mmkubernetes.rst
@@ -240,8 +240,6 @@ filenamerules
 When processing json-file logs, these are the lognorm rules to use to
 match the filename and extract metadata.  The default value is::
 
-    rule=:/var/log/containers/%pod_name:char-to:.%.%container_hash:char-to:_%_%names\
-    pace_name:char-to:_%_%container_name_and_id:char-to:.%.log
     rule=:/var/log/containers/%pod_name:char-to:_%_%namespace_name:char-to:_%_%contai\
     ner_name_and_id:char-to:.%.log
 


### PR DESCRIPTION
The pod_name field match in the filename rule must include
everything up to the first _, including dots.

see https://github.com/rsyslog/rsyslog/pull/2824