### PR TITLE
DOC for rsyslog/pull/2774: introducing PreserveCase

### DIFF
--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -310,6 +310,21 @@ information about priority Strings
 `here <https://gnutls.org/manual/html_node/Priority-Strings.html>`_.
 
 
+PreserveCase
+^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "on", "no", "none"
+
+.. versionadded:: 8.37.0
+
+This parameter is for controlling the case in fromhost.  If preservecase is set to "off", the case in fromhost is not preserved.  E.g., 'host1.example.org' the message was received from 'Host1.Example.Org'.  Default to "on" for the backword compatibility.
+
+
 Input Parameters
 ----------------
 

--- a/source/configuration/modules/imudp.rst
+++ b/source/configuration/modules/imudp.rst
@@ -149,6 +149,21 @@ set to 32. It may increase in the future when massive multicore
 processors become available.
 
 
+PreserveCase
+^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "off", "no", "none"
+
+.. versionadded:: 8.37.0
+
+This parameter is for controlling the case in fromhost.  If preservecase is set to "on", the case in fromhost is preserved.  E.g., 'Host1.Example.Org' when the message was received from 'Host1.Example.Org'.  Default to "off" for the backword compatibility.
+
+
 .. index:: imudp; input parameters
 
 


### PR DESCRIPTION
Introducing an option preservecase to imudp and imtcp module for managing the case of FROMHOST value.

Usage:
  module(load="imudp" [preservecase="on"|"off"])
  module(load="imtdp" [preservecase="on"|"off"])

If preservecase="on", FROMHOST value is handled in the case sensitive manner.
If preservecase="off", FROMHOST value is handled in the case insensitive manner.

To maintain the current behaviour, the default value of preservecase is
"on" for imtcp and "off" for imudp.

References:
  https://github.com/rsyslog/rsyslog/pull/2774
  https://bugzilla.redhat.com/show_bug.cgi?id=1309698