### PR TITLE
omprog: document 'useTransactions' flag as experimental

### DIFF
--- a/source/configuration/modules/omprog.rst
+++ b/source/configuration/modules/omprog.rst
@@ -211,7 +211,9 @@ confirmed by returning ``OK``, and the individual messages by returning
 
 .. warning::
 
-   There is currently a `known issue
+   This feature is currently **experimental**. It could change in future releases
+   without keeping backwards compatibility with existing configurations or the
+   specified interface. There is also a `known issue
    <https://github.com/rsyslog/rsyslog/issues/2420>`_ with the use of
    transactions together with ``confirmMessages=on``.
 


### PR DESCRIPTION
The rsyslog module interface was not designed to support modules that
can act both as transactional and non-transactional according to
a configuration parameter. The old transaction interface (incidentally)
supports this, but it is not supported by the new transaction interface.

Therefore a future change is envisaged regarding this feature, that will
likely break backwards compatibility.