### PR TITLE
templates: Remove redundant TODO block

### DIFF
--- a/source/configuration/templates.rst
+++ b/source/configuration/templates.rst
@@ -26,9 +26,6 @@ specified via $template legacy statements.
    are available.
 
 
-TODO: :doc:`rsyslog properties reference <properties>` for a list of which
-
-
 Template processing
 ===================
 


### PR DESCRIPTION
Remove the TODO block that is essentially already present a couple of
lines above