### PR TITLE
Update tls.rst

### DIFF
--- a/source/tutorials/tls.rst
+++ b/source/tutorials/tls.rst
@@ -145,13 +145,14 @@ Client Setup
 ~~~~~~~~~~~~
 
 The client setup is equally simple. You need less certificates, just the
-CA cert. 
+CA & client cert. 
 
     ::
 
-        # certificate files - just CA for a client
+        # certificate files - just CA & cert for a client
         $DefaultNetstreamDriverCAFile /path/to/contrib/gnutls/ca.pem
-
+        $DefaultNetstreamDriverCertFile /path/to/contrib/gnutls/cert.pem
+        
         # set up the action
         $DefaultNetstreamDriver gtls # use gtls netstream driver
         $ActionSendStreamDriverMode 1 # require TLS for the connection


### PR DESCRIPTION
Propose to update the client documentation to include the certificate. I was working on getting client rsyslog set up for over a week and not until I did detailed GnuTLS debugging on the destination I found that it would not accept my TLS syslogs unless I also sent the cert along with the client.