### PR TITLE
Escape single quotes in git log command

### DIFF
--- a/source/conf_helpers.py
+++ b/source/conf_helpers.py
@@ -78,7 +78,7 @@ def get_next_stable_version():
 def get_current_commit_hash():
     """Return commit hash string"""
 
-    commit_hash = subprocess.check_output(['git', 'log', "--pretty=format:'%h'", 'HEAD', '-n1']).decode("utf-8")
+    commit_hash = subprocess.check_output(['git', 'log', '--pretty=format:%h', 'HEAD', '-n1']).decode("utf-8")
 
     return commit_hash
 


### PR DESCRIPTION
Escape the single quotes in the git log format command so that they are not interpreted literally and included with the doc title when output files are generated.

I'm assuming that the behavior is not intentional, but please feel free to reject this PR if it is.

closes rsyslog/rsyslog-doc#743
