### PR TITLE
fixed typo in case-sensitive global() option

### DIFF
--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -357,7 +357,7 @@ The following parameters can be set:
   providing the ability to see initial error messages. Might also be
   useful for some practical deployments.
 
-- **variables.caseSensitve** [boolean (on/off)] available 8.30.0+
+- **variables.caseSensitive** [boolean (on/off)] available 8.30.0+
 
   **Default:** off
 


### PR DESCRIPTION
this led to errors and confusion when copy-pasting the parameter
from doc to live config.