### PR TITLE
correct documentation of substring function

### DIFF
--- a/source/rainerscript/functions/rs-substring.rst
+++ b/source/rainerscript/functions/rs-substring.rst
@@ -12,18 +12,19 @@ at most subStringLength characters long.
 
 .. note::
 
-   The first character of the string has the value 1. So if you set
-   start to '3', the substring will start with the third character.
+   The first character of the string has the value 0. So if you set
+   start to '2', the substring will start with the third character.
 
 
 Example
 =======
 
-In the following example a substring from the message property is created,
-starting with the 10th character and being 5 characters long.
+In the following example a substring from the string is created,
+starting with the 4th character and being 5 characters long.
 
 .. code-block:: none
 
-   substring($msg, 10, 5)
+   substring("123456789", 3, 5)
 
 
+This example will result in the substring "45678".


### PR DESCRIPTION
The behaviour of RainerScript function substring
was documented wrong.

Closes https://github.com/rsyslog/rsyslog/issues/3344