### PR TITLE
omclickhouse: add documentation for new parameters

### DIFF
--- a/source/configuration/modules/omclickhouse.rst
+++ b/source/configuration/modules/omclickhouse.rst
@@ -185,6 +185,35 @@ Note that e.g. after search index reconfiguration (e.g. dropping the mandatory
 attribute) a resubmit may be succesful.
 
 
+allowUnsignedCerts
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "on", "no", "none"
+
+The module accepts connections to servers, which have unsigned certificates.
+If this parameter is disabled, the module will verify whether the certificates
+are authentic.
+
+
+healthCheckTimeout
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "int", "3500", "no", "none"
+
+This parameter sets the timeout for checking the availability
+of ClickHouse. Value is given in milliseconds.
+
+
 .. _omclickhouse-statistic-counter:
 
 Statistic Counter


### PR DESCRIPTION
Documentation for following parameters were added
1. allowUnsignedCerts, which allows connections with
servers, without checking if the certificates are authentic.
2. healthCheckTimeout, which sets the timeout for the
availability check for the clickhouse server.