### PR TITLE
add support for skipverifyhost

### DIFF
--- a/source/configuration/modules/mmkubernetes.rst
+++ b/source/configuration/modules/mmkubernetes.rst
@@ -222,6 +222,22 @@ If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYPEER` option to
 `0`.  You are strongly discouraged to set this to `"on"`.  It is
 primarily useful only for debugging or testing.
 
+.. _skipverifyhost:
+
+skipverifyhost
+^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "off", "no", "none"
+
+If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYHOST` option to
+`0`.  You are strongly discouraged to set this to `"on"`.  It is
+primarily useful only for debugging or testing.
+
 .. _de_dot:
 
 de_dot

--- a/source/configuration/modules/omclickhouse.rst
+++ b/source/configuration/modules/omclickhouse.rst
@@ -200,6 +200,21 @@ If this parameter is disabled, the module will verify whether the certificates
 are authentic.
 
 
+skipverifyhost
+^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "off", "no", "none"
+
+If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYHOST` option to
+`0`.  You are strongly discouraged to set this to `"on"`.  It is
+primarily useful only for debugging or testing.
+
+
 healthCheckTimeout
 ^^^^^^^^^^^^^^^^^^
 

--- a/source/configuration/modules/omelasticsearch.rst
+++ b/source/configuration/modules/omelasticsearch.rst
@@ -490,6 +490,38 @@ corresponding to the cert `tls.mycert` used for doing client cert auth against
 Elasticsearch.  This file is in PEM format, and must be unencrypted, so take
 care to secure it properly.  For example: `/etc/rsyslog.d/es-client-key.pem`
 
+.. _omelasticsearch-allowunsignedcerts:
+
+allowunsignedcerts
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "off", "no", "none"
+
+If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYPEER` option to
+`0`.  You are strongly discouraged to set this to `"on"`.  It is
+primarily useful only for debugging or testing.
+
+.. _omelasticsearch-skipverifyhost:
+
+skipverifyhost
+^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "off", "no", "none"
+
+If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYHOST` option to
+`0`.  You are strongly discouraged to set this to `"on"`.  It is
+primarily useful only for debugging or testing.
+
 .. _omelasticsearch-bulkid:
 
 bulkid

--- a/source/configuration/modules/omhttp.rst
+++ b/source/configuration/modules/omhttp.rst
@@ -446,6 +446,34 @@ tls.myprivkey
 
 The parameters sets the path to the SSL private key. Expects .pem format.
 
+allowunsignedcerts
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "off", "no", "none"
+
+If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYPEER` option to
+`0`.  You are strongly discouraged to set this to `"on"`.  It is
+primarily useful only for debugging or testing.
+
+skipverifyhost
+^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "boolean", "off", "no", "none"
+
+If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYHOST` option to
+`0`.  You are strongly discouraged to set this to `"on"`.  It is
+primarily useful only for debugging or testing.
+
 reloadonhup
 ^^^^^^^^^^^
 


### PR DESCRIPTION
docs for https://github.com/rsyslog/rsyslog/pull/3558
Add ability to specify the libcurl CURLOPT_SSL_VERIFYHOST
option to skip verification of the hostname in the peer cert.
WARNING: This option is insecure, and should only be used
for testing. The default value is off, meaning, the hostname
will be verified by default.