### PR TITLE
Fixed initial key generation command parameters

### DIFF
--- a/source/tutorials/tls_cert_machine.rst
+++ b/source/tutorials/tls_cert_machine.rst
@@ -47,7 +47,7 @@ unique name. If not, you can not apply proper access control.
 
 ::
 
-    [root@rgf9dev sample]# certtool --generate-privkey --outfile key.pem --sec-param 2048
+    [root@rgf9dev sample]# certtool --generate-privkey --outfile key.pem --bits 2048
     Generating a 2048 bit RSA private key...
     [root@rgf9dev sample]# certtool --generate-request --load-privkey key.pem --outfile request.pem
     Generating a PKCS #10 certificate request...


### PR DESCRIPTION
The command `certtool --generate-privkey --outfile key.pem --sec-param 2048` fails with the error: ```Unknown security parameter string: 2048```. This is because `--sec-param` expects only the following parameters - [low, legacy, medium, high, ultra]. It's used as an alternative to the `--bits` flag. Running with `--bits` will fix the issue and still generate a 2048 bit key.

Source: `man certtool`