### PR TITLE
Fix gelf documentation

### DIFF
--- a/source/tutorials/gelf_forwarding.rst
+++ b/source/tutorials/gelf_forwarding.rst
@@ -26,9 +26,9 @@ sent to Graylog.
         property(name="hostname")
         constant(value="\",\"short_message\":\"")
         property(name="msg" format="json")
-        constant(value="\",\"timestamp\":\"")
+        constant(value="\",\"timestamp\":")
         property(name="timegenerated" dateformat="unixtimestamp")
-        constant(value="\",\"level\":\"")
+        constant(value=",\"level\":\"")
         property(name="syslogseverity")
         constant(value="\"}")
     }
@@ -46,12 +46,16 @@ action.
 ::
 
     # syslog forwarder via UDP
-    action(type="omfwd" target="graylogserver" port="514" protocol="udp" template="gelf")
+    action(type="omfwd" target="graylogserver" port="12201" protocol="udp" template="gelf")
 
 We now have a syslog forwarding action. This uses the omfwd module. Please
 note that the case above only works for UDP transport. When using TCP, 
-Graylog expects a Nullbyte as message delimiter. This is currently not 
-possible with rsyslog.
+Graylog expects a Nullbyte as message delimiter. So, to use TCP, you need to change delimiter via `TCP_FrameDelimiter <../configuration/modules/omfwd.html#tcp-framedelimiter>`_ option.
+
+::
+
+    # syslog forwarder via TCP
+    action(type="omfwd" target="graylogserver" port="12201" protocol="tcp" template="gelf" TCP_FrameDelimiter="0" KeepAlive="on")
 
 Conclusion
 ----------


### PR DESCRIPTION
Now gelf forwarding tutorial claims that you cannot use omwd tcp and graylog together due nullbyte as frame delimiter.
It is false. Frame Delimiter is configurable in rsyslog since 2017. https://github.com/rsyslog/rsyslog/issues/1602

Also, timestamp field in modern gelf should be number, not string. So quotes around timestamp value is against gelf standard.

This PR is fixing both issues.
