### PR TITLE
Fix typo in imptcp and imtcp

### DIFF
--- a/source/configuration/modules/imptcp.rst
+++ b/source/configuration/modules/imptcp.rst
@@ -381,7 +381,7 @@ SupportOctetCountedFraming
    :widths: auto
    :class: parameter-table
 
-   "binary", "on", "no", "``$InputPTCPSupportOctetCountedFraming``"
+   "binary", "on", "no", "``$InputPTCPServerSupportOctetCountedFraming``"
 
 The legacy octed-counted framing (similar to RFC5425
 framing) is activated. This is the default and should be left

--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -509,7 +509,7 @@ SupportOctetCountedFraming
    :widths: auto
    :class: parameter-table
 
-   "binary", "on", "no", "``$InputTCPSupportOctetCountedFraming``"
+   "binary", "on", "no", "``$InputTCPServerSupportOctetCountedFraming``"
 
 If set to "on", the legacy octed-counted framing (similar to RFC5425
 framing) is activated. This should be left unchanged until you know


### PR DESCRIPTION
Missing "Server" in legacy directive of
SupportOctetCountedFraming in imtcp and imptcp.

imtcp
Wrong:   $InputTCPSupportOctetCountedFraming
Correct: $InputTCPServerSupportOctetCountedFraming

imptcp
Wrong:   $InputPTCPSupportOctetCountedFraming
Correct: $InputPTCPServerSupportOctetCountedFraming