### PR TITLE
rainerscript/global.rst: control characters escaping options

### DIFF
--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -212,6 +212,67 @@ The following parameters can be set:
   Note that escaping is the traditional behavior and existing scripts
   may get into trouble if this is changed to "off".
 
+- **parser.controlCharacterEscapePrefix** [char]
+
+  **Default:** '#'
+
+  This option specifies the prefix character to be used for control
+  character escaping (see option
+  *parser.escapeControlCharactersOnReceive*).
+
+- **parser.escape8BitCharactersOnReceive** [on/off]
+
+  **Default:** off
+
+  This parameter instructs rsyslogd to replace non US-ASCII characters
+  (those that have the 8th bit set) during reception of the message.
+  This may be useful for some systems. Please note that this escaping
+  breaks Unicode and many other encodings. Most importantly, it can be
+  assumed that Asian and European characters will be rendered hardly
+  readable by this settings. However, it may still be useful when the
+  logs themselves are primarily in English and only occasionally contain
+  local script. If this option is turned on, all control-characters are
+  converted to a 3-digit octal number and be prefixed with the
+  *parser.controlCharacterEscapePrefix* character (being '#' by default).
+
+  **Warning:**
+
+  -  turning on this option most probably destroys non-western character
+     sets (like Japanese, Chinese and Korean) as well as European
+     character sets.
+  -  turning on this option destroys digital signatures if such exists
+     inside the message
+  -  if turned on, the drop-cc, space-cc and escape-cc `property
+     replacer <property_replacer.html>`_ options do not work as expected
+     because control characters are already removed upon message
+     reception. If you intend to use these property replacer options, you
+     must turn off *parser.escape8BitCharactersOnReceive*.
+
+- **parser.escapeControlCharactersOnReceive** [on/off]
+
+  **Default:** on
+
+  This parameter instructs rsyslogd to replace control characters during
+  reception of the message. The intent is to provide a way to stop
+  non-printable messages from entering the syslog system as whole. If this
+  option is turned on, all control-characters are converted to a 3-digit
+  octal number and be prefixed with the parser.controlCharacterEscapePrefix
+  character (being '#' by default). For example, if the BEL character
+  (ctrl-g) is included in the message, it would be converted to '#007'.
+  To be compatible to sysklogd, this option must be turned on.
+
+  **Warning:**
+
+  -  turning on this option most probably destroys non-western character
+     sets (like Japanese, Chinese and Korean)
+  -  turning on this option destroys digital signatures if such exists
+     inside the message
+  -  if turned on, the drop-cc, space-cc and escape-cc `property
+     replacer <property_replacer.html>`_ options do not work as expected
+     because control characters are already removed upon message
+     reception. If you intend to use these property replacer options, you
+     must turn off *parser.escapeControlCharactersOnReceive*.
+
 
 - **senders.keepTrack** [on/off] available 8.17.0+
 

--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -256,7 +256,7 @@ The following parameters can be set:
   reception of the message. The intent is to provide a way to stop
   non-printable messages from entering the syslog system as whole. If this
   option is turned on, all control-characters are converted to a 3-digit
-  octal number and be prefixed with the parser.controlCharacterEscapePrefix
+  octal number and be prefixed with the *parser.controlCharacterEscapePrefix*
   character (being '#' by default). For example, if the BEL character
   (ctrl-g) is included in the message, it would be converted to '#007'.
   To be compatible to sysklogd, this option must be turned on.


### PR DESCRIPTION
Copied global control character escaping options from legacy format to rainerscript/global doc and changed to advanced format.