### PR TITLE
omhttp: update inverted examples for kafka and loki

### DIFF
--- a/source/configuration/modules/omhttp.rst
+++ b/source/configuration/modules/omhttp.rst
@@ -272,15 +272,15 @@ Each message on the "Inputs" line is the templated log line that is fed into the
 
 .. code-block:: text
 
-    Inputs: {"stream": {"tag1":"value1"}, values:[[ "%timestamp%", "message 1" ]]} {"stream": {"tag2":"value2"}, values:[[ %timestamp%, "message 2" ]]}
-    Output: {"streams": [{"stream": {"tag1":"value1"}, values:[[ "%timestamp%", "message 1" ]]},{"stream": {"tag2":"value2"}, values:[[ %timestamp%, "message 2" ]]}]}
+    Inputs: {"msg": "message 1"} {"msg"": "message 2"} {"msg": "message 3"}
+    Output: {"records": [{"value": {"msg": "message 1"}}, {"value": {"msg": "message 2"}}, {"value": {"msg": "message 3"}}]}
 
 4. *lokirest* - Builds a JSON object that conforms to the `Loki Rest specification <https://github.com/grafana/loki/blob/master/docs/api.md#post-lokiapiv1push>`_. This mode requires that each message is parseable JSON, since the plugin parses each message as JSON while building the batch object. Additionally, the operator is responsible for providing index keys, and message values.
 
 .. code-block:: text
 
-    Inputs: {"msg": "message 1"} {"msg"": "message 2"} {"msg": "message 3"}
-    Output: {"records": [{"value": {"msg": "message 1"}}, {"value": {"msg": "message 2"}}, {"value": {"msg": "message 3"}}]}
+    Inputs: {"stream": {"tag1":"value1"}, values:[[ "%timestamp%", "message 1" ]]} {"stream": {"tag2":"value2"}, values:[[ %timestamp%, "message 2" ]]}
+    Output: {"streams": [{"stream": {"tag1":"value1"}, values:[[ "%timestamp%", "message 1" ]]},{"stream": {"tag2":"value2"}, values:[[ %timestamp%, "message 2" ]]}]}
 
 batch.maxsize
 ^^^^^^^^^^^^^


### PR DESCRIPTION
The documentation for `lokirest` introduced in #862 inverted examples between kafkarest and the newly added lokirest.