### PR TITLE
Remove dynafile.donotsuspend from global directive

### DIFF
--- a/source/configuration/modules/omfile.rst
+++ b/source/configuration/modules/omfile.rst
@@ -223,7 +223,9 @@ dynafile.donotsuspend
 
    "binary", "on", "no", "none"
 
-DynaFiles are not suspended.
+This permits SUSPENDing dynafile actions. Traditionally, SUSPEND mode was
+never entered for dynafiles as it would have blocked overall processing
+flow. Default is not to suspend (and thus block).
 
 
 Action Parameters

--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -465,14 +465,6 @@ The following parameters can be set:
   need to switch it back to "on", except for the case to be mentioned.
   This is also the reason why we switched the default.
 
-- **dynafile.donotsuspend** [boolean (on/off)] available 8.32.0+
-
-  **Default:** on
-
-  This permits SUSPENDing dynafile actions. Traditionally, SUSPEND mode was
-  never entered for dynafiles as it would have blocked overall processing
-  flow. Default is not to suspend (and thus block).
-
 - **internal.developeronly.options**
 
   This is NOT to be used by end users. It provides rsyslog developers the


### PR DESCRIPTION
While I was reading the documentation about the ```global``` directive, I discovered that ```dynafile.donotsuspend``` was accidentally added to this section. It was designed to be an ```omfile``` module parameter.

Introduced in 6b3ef17ceff9aa61f86499ad1204a47084d7c628.