### PR TITLE
tls: correct the StreamDriver.PermitExpiredCerts doc

### DIFF
--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -282,9 +282,9 @@ It can have one of the following values:
 
 -  on = Expired certificates are allowed
 
--  off = Expired certificates are not allowed
+-  off = Expired certificates are not allowed  (Default, changed from warn to off since Version 8.2012.0)
 
--  warn = Expired certificates are allowed but warning will be logged (Default due legacy support)
+-  warn = Expired certificates are allowed but warning will be logged
 
 
 StreamDriver.CheckExtendedKeyPurpose

--- a/source/configuration/modules/omfwd.rst
+++ b/source/configuration/modules/omfwd.rst
@@ -489,9 +489,9 @@ It can have one of the following values:
 
 -  on = Expired certificates are allowed
 
--  off = Expired certificates are not allowed
+-  off = Expired certificates are not allowed  (Default, changed from warn to off since Version 8.2012.0)
 
--  warn = Expired certificates are allowed but warning will be logged (Default due legacy support)
+-  warn = Expired certificates are allowed but warning will be logged
 
 
 StreamDriverPermittedPeers


### PR DESCRIPTION
corrected the default for StreamDriver.PermitExpiredCerts.

closes: https://github.com/rsyslog/rsyslog-doc/issues/966