### PR TITLE
omkafka: added dynaKey available version

### DIFF
--- a/source/configuration/modules/omkafka.rst
+++ b/source/configuration/modules/omkafka.rst
@@ -78,11 +78,11 @@ DynaKey
 ^^^^^^^
 
 .. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive", "Available since"
    :widths: auto
    :class: parameter-table
 
-   "binary", "off", "no", "none"
+   "binary", "off", "no", "none", v8.1903
 
 If set, the key parameter becomes a template for the key to base the
 partitioning on. 


### PR DESCRIPTION
The **DynaKey** param is available since [v8.1903](https://github.com/rsyslog/rsyslog/pull/3350), but it's not mentioned in the [document](https://www.rsyslog.com/doc/master/configuration/modules/omkafka.html#dynakey)