### PR TITLE
ompgsql: Use option.stdsql instead of option.sql in examples

### DIFF
--- a/source/configuration/modules/ompgsql.rst
+++ b/source/configuration/modules/ompgsql.rst
@@ -182,7 +182,7 @@ A Templated example.
 
 .. code-block:: none
 
-   template(name="sql-syslog" type="list" option.sql="on") {
+   template(name="sql-syslog" type="list" option.stdsql="on") {
      constant(value="INSERT INTO SystemEvents (message, timereported) values ('")
      property(name="msg")
      constant(value="','")
@@ -206,7 +206,7 @@ An action queue and templated example.
 
 .. code-block:: none
 
-   template(name="sql-syslog" type="list" option.sql="on") {
+   template(name="sql-syslog" type="list" option.stdsql="on") {
      constant(value="INSERT INTO SystemEvents (message, timereported) values ('")
      property(name="msg")
      constant(value="','")


### PR DESCRIPTION
Postgres uses double single quotes `''` to escape single quotes in strings [1].
For a default postgres setup the `option.stdsql` should be used instead of `option.sql` [2].

[1] https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
[2] https://www.rsyslog.com/doc/v8-stable/configuration/templates.html#options

