### PR TITLE
fix: backslash escape

### DIFF
--- a/source/configuration/templates.rst
+++ b/source/configuration/templates.rst
@@ -135,7 +135,7 @@ sample of that use case from the rsylsog testbench:
 
 The following escape sequences are recognized inside the constant text:
 
--  \\\\ - single backslash
+-  \\ - single backslash
 -  \\n - LF
 -  \\ooo - (three octal digits) - represents a character with this
    octal numerical value (e.g. \\101 equals "A"). Note that three octal digits


### PR DESCRIPTION
again, too many `\` caused double backslash in the documentation