### PR TITLE
Add the "batchsize" parameter to the imhiredis module.

### DIFF
--- a/source/configuration/modules/imhiredis.rst
+++ b/source/configuration/modules/imhiredis.rst
@@ -79,6 +79,22 @@ Defines the mode to use for the module.
 Should be either "**subscribe**" (:ref:`imhiredis_channel_mode`), or "**queue**" (:ref:`imhiredis_queue_mode`) (case-sensitive).
 
 
+.. _imhiredis_batchsize:
+
+batchsize
+^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "number", "10", "yes", "none"
+
+Defines the dequeue batch size for redis pipelining.
+imhiredis will read "**batchsize**" elements from redis at a time.
+
+
 .. _imhiredis_key:
 
 key


### PR DESCRIPTION
imhiredis dequeue batch size for redis pipelining was previously hardcoded to 10. 
This change allows to set the size of the batch via the "batchsize" parameter of the imhiredis module.