### PR TITLE
Add doc for TLS CRL (Certificate revocation list) List Parameters

### DIFF
--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -738,6 +738,22 @@ streamDriver.CAFile
 This permits to override the DefaultNetstreamDriverCAFile global parameter on the input()
 level. For further details, see the global parameter.
 
+streamDriver.CRLFile
+^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "optional", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "global parameter", "no", "none"
+
+.. versionadded:: 8.2308.0
+
+This permits to override the CRL (Certificate revocation list) file set via `global()` config
+object at the per-action basis. This parameter is ignored if the netstream driver and/or its
+mode does not need or support certificates.
+
 streamDriver.KeyFile
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/source/configuration/modules/omfwd.rst
+++ b/source/configuration/modules/omfwd.rst
@@ -571,6 +571,22 @@ This permits to override the CA file set via `global()` config object at the
 per-action basis. This parameter is ignored if the netstream driver and/or its
 mode does not need or support certificates.
 
+StreamDriver.CRLFile
+^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "optional", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "global() default", "no", "none"
+
+.. versionadded:: 8.2308.0
+
+This permits to override the CRL (Certificate revocation list) file set via `global()` config
+object at the per-action basis. This parameter is ignored if the netstream driver and/or its
+mode does not need or support certificates.
+
 StreamDriver.KeyFile
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -47,6 +47,11 @@ The following parameters can be set:
   For `TLS syslog <http://www.rsyslog.com/doc/rsyslog_secure_tls.html>`_,
   the CA certificate that can verify the machine keys and certs (see below)
 
+- **defaultNetstreamDriverCRLFile**
+
+  For `TLS syslog <http://www.rsyslog.com/doc/rsyslog_secure_tls.html>`_,
+  the CRL File contains a List contains a list of revoked certrificates.
+
 - **defaultNetstreamDriverKeyFile**
 
   Machine private key


### PR DESCRIPTION
- add imtcp/omfwd streamDriver.CRLFile parameter
- and global defaultNetstreamDriverCRLFile parameter

closes: https://github.com/rsyslog/rsyslog-doc/issues/1011