### PR TITLE
add missing doc: uuid message property

### DIFF
--- a/source/configuration/properties.rst
+++ b/source/configuration/properties.rst
@@ -166,6 +166,24 @@ The following message properties exist:
   generated messages ("rsyslogd", "imuxsock", "imklog") should go to a
   different place than messages generated somewhere else.
 
+**uuid**
+
+  *Only Available if rsyslog is build with --enable-uuid*
+
+  A UUID for the message. It is not present by default, but will be created
+  on first read of the uuid property. Thereafter, in the local rsyslog
+  instance, it will always be the same value. This is also true if rsyslog
+  is restarted and messages stayed in an on-disk queue.
+
+  Note well: the UUID is **not** automatically transmitted to remote
+  syslog servers when forwarding. If that is needed, a special template
+  needs to be created that contains the uuid. Likewise, the receiver must
+  parse that UUID from that template.
+
+  The uuid property is most useful if you would like to track a single
+  message across multiple local destination. An example is messages being
+  written to a database as well as to local files.
+
 **jsonmesg**
 
   *Available since rsyslog 8.3.0*


### PR DESCRIPTION
It was obviously forgotten to add this doc when the user-contributed uuid enhancement was merged. This happened quite a while ago.