### PR TITLE
 Fix incorrect parameter name for omfwd module in documentation

### DIFF
--- a/source/configuration/modules/omfwd.rst
+++ b/source/configuration/modules/omfwd.rst
@@ -38,7 +38,7 @@ Template
    :widths: auto
    :class: parameter-table
 
-   "word", "RSYSLOG_TraditionalForwardFormat", "no", "``$ActionForwardDefaultTemplateName``"
+   "word", "RSYSLOG_TraditionalForwardFormat", "no", "``$ActionForwardDefaultTemplate``"
 
 Sets a non-standard default template for this module.
  


### PR DESCRIPTION
This PR corrects the name of a configuration parameter in the documentation for the omfwd module. The parameter ActionForwardDefaultTemplateName is incorrect and should be ActionForwardDefaultTemplate.

Details:
While testing with rsyslog v8.2102.0, I encountered an error when using the parameter of the documentation ActionForwardDefaultTemplateName:
![imagen](https://github.com/rsyslog/rsyslog-doc/assets/34064559/1218c5ad-953b-4df5-a7d5-e96b17069d1c)

Switching to ActionForwardDefaultTemplate resolved the issue, and no error message was shown. I haven't tested the current latest version, but searching in the master branch of the rsyslog codebase, it seems that the name of the parameter is ActionForwardDefaultTemplate, as it is in my rsyslog version.