### PR TITLE
Fix typos

### DIFF
--- a/source/compatibility/v7compatibility.rst
+++ b/source/compatibility/v7compatibility.rst
@@ -125,8 +125,8 @@ from the same
 processing. It is now also integrated in to the more generic rate-limiting
 processing.
 
-User-Noticable Changes
-......................
+User-Noticeable Changes
+.......................
 The code works almost as before, with two exceptions:
 
 * The suppression amount can be different, as the new algorithm

--- a/source/configuration/converting_to_new_format.rst
+++ b/source/configuration/converting_to_new_format.rst
@@ -4,7 +4,7 @@ Converting older formats to |FmtAdvancedName|
 First of all, converting of older formats is not strictly necessary. All
 formats can be mixed and matched and play well together.
 
-There are stil a number of reasons to convert older formats:
+There are still a number of reasons to convert older formats:
 
 * existing simple constructs need to be enhanced and become more complex
 * aid future extensions
@@ -15,7 +15,7 @@ Do not overdo conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Note: simple facility and severity based filters which trigger writing to
-files can actually be very well expressd in |FmtBasicName|. So if you have
+files can actually be very well expressed in |FmtBasicName|. So if you have
 something like::
 
     mail.info   /var/log/maillog
@@ -170,7 +170,7 @@ The latter is much easier to understand and less error-prone when extended.
 
 A common construct is to send messages to a remote host based on some message
 content and then not further process it. This involves the ``stop`` statement
-(or it's very old-time equivalent tilde ('``~``'). It may be specfied as such::
+(or it's very old-time equivalent tilde ('``~``'). It may be specified as such::
 
    :msg, contains, "error" @remote
    & ~

--- a/source/configuration/droppriv.rst
+++ b/source/configuration/droppriv.rst
@@ -27,5 +27,5 @@ we strongly advise to use numerical IDs instead of user or group
 names when configuring privilege drop.
 
 Privilege drop is configured via the
-:doc:`global configuraton object<../rainerscript/global>` under the
+:doc:`global configuration object<../rainerscript/global>` under the
 "`privilege.`" set of parameters.

--- a/source/configuration/filters.rst
+++ b/source/configuration/filters.rst
@@ -85,7 +85,7 @@ The intent is to log all facilities at debug or higher, except for local6,
 which should only log at err or higher.
 
 Unfortunately, local6.err will permit error severity and higher, but will
-*not* exclude lower sevrity messages from facility local6.
+*not* exclude lower severity messages from facility local6.
 
 As an alternative, you can explicitely exclude all severities that you do
 not want to match. For the above case, this selector is equivalent to the

--- a/source/configuration/global/options/rsconf1_includeconfig.rst
+++ b/source/configuration/global/options/rsconf1_includeconfig.rst
@@ -3,7 +3,7 @@ $IncludeConfig
 
 .. warning::
 
-   This legacy directive has been superseeded by the rsyslog
+   This legacy directive has been superseded by the rsyslog
    :doc:`include() <../../../rainerscript/include>`
    configuration object.
    While it is save to use the legacy statement, we highly

--- a/source/configuration/modules/imbatchreport.rst
+++ b/source/configuration/modules/imbatchreport.rst
@@ -126,7 +126,7 @@ DeduplicateSpaces
   "binary", "no", "", "on"
 
 The parameter modify the way consecutive spaces like chars are managed.
-When it is setted to "on", consecutive spaces like chars are reduced to a single one
+When it is set to "on", consecutive spaces like chars are reduced to a single one
 and trailing space like chars are suppressed. 
 
 Delete

--- a/source/configuration/modules/imfile.rst
+++ b/source/configuration/modules/imfile.rst
@@ -462,7 +462,7 @@ This parameter works in conjunction with `escapeLF`. It is only
 honored if `escapeLF="on"`.
 
 It permits to replace the default escape sequence by a different character
-sequence. The default historically is inconsistent and denpends on which
+sequence. The default historically is inconsistent and depends on which
 functionality is used to read the file. It can be either "#012" or "\\n". If
 you want to retain that default, do not configure this parameter.
 
@@ -697,7 +697,7 @@ rsyslog's initial processing of the file monitors.
    Depending on the number and location of existing files, this initial
    startup processing may take some time as well. If another process
    creates a new file at exactly the time of startup processing and writes
-   data to it, rsyslog might detect this file and it's data as prexisting
+   data to it, rsyslog might detect this file and it's data as preexisting
    and may skip it. This race is inevitable. So when freshStartTail is used,
    some risk of data loss exists. The same holds true if between the last
    shutdown of rsyslog and its restart log file content has been added.

--- a/source/configuration/modules/imhiredis.rst
+++ b/source/configuration/modules/imhiredis.rst
@@ -315,7 +315,7 @@ stream.autoclaimIdleTime
 
    "positive number", "0", "no", "none"
 
-| When using :ref:`imhiredis_stream_mode` with :ref:`imhiredis_stream_consumergroup` and :ref:`imhiredis_stream_consumername`, determines if the module should check for pending IDs that exceed this time (**in milliseconds**) to assume the original consumer failed to acknowledge the log and claim them for their own (see `the redis ducumentation <https://redis.io/docs/data-types/streams-tutorial/#automatic-claiming>`_ on this subject for more details on how that works).
+| When using :ref:`imhiredis_stream_mode` with :ref:`imhiredis_stream_consumergroup` and :ref:`imhiredis_stream_consumername`, determines if the module should check for pending IDs that exceed this time (**in milliseconds**) to assume the original consumer failed to acknowledge the log and claim them for their own (see `the redis documentation <https://redis.io/docs/data-types/streams-tutorial/#automatic-claiming>`_ on this subject for more details on how that works).
 | Has no influence in the other modes (queue or channel) and will be ignored.
 
 .. note::

--- a/source/configuration/modules/imhttp.rst
+++ b/source/configuration/modules/imhttp.rst
@@ -261,7 +261,7 @@ basicAuthFile
    "string", "no", "none", "none"
 
 Configures a `htpasswd <https://httpd.apache.org/docs/2.4/programs/htpasswd.html>`_ file and enables `basic authentication <https://en.wikipedia.org/wiki/Basic_access_authentication>`_ on http request received on this input.
-If this option is not set, basic authentation will not be enabled.
+If this option is not set, basic authentication will not be enabled.
 
 
 Statistic Counter

--- a/source/configuration/modules/imjournal.rst
+++ b/source/configuration/modules/imjournal.rst
@@ -351,7 +351,7 @@ Main
 
 When this option is turned on within the input module, imjournal will run the
 target ruleset in the main thread and will be stop taking input if the output
-module is not accepting data. If multiple input moduels set `main` to true, only
+module is not accepting data. If multiple input modules set `main` to true, only
 the first one will be affected. The non `main` rulesets will run in the
 background thread and not affected by the output state.
 

--- a/source/configuration/modules/imkmsg.rst
+++ b/source/configuration/modules/imkmsg.rst
@@ -169,7 +169,7 @@ This is Linux specific module and requires /dev/kmsg device with
 structured kernel logs.
 
 This module does not support rulesets. All messages are delivered to the
-default rulseset.
+default ruleset.
 
 
 

--- a/source/configuration/modules/impcap.rst
+++ b/source/configuration/modules/impcap.rst
@@ -116,7 +116,7 @@ The file must respect the `pcap file format specification <https://www.tcpdump.o
 for the module to run.**
 
 .. Warning::
-    This functionality is not intended for production environnments,
+    This functionality is not intended for production environments,
     it is designed for development/tests. 
 
 
@@ -174,7 +174,7 @@ ruleset
 
    "word", "none", "no", "none"
 
-Assign messages from thi simput to a specific Rsyslog ruleset.
+Assign messages from this input to a specific Rsyslog ruleset.
 
 
 .. _no_buffer:

--- a/source/configuration/modules/improg.rst
+++ b/source/configuration/modules/improg.rst
@@ -17,7 +17,7 @@ from pipe(s) (stdout of the external process).
 **Limitation:** `select()` seems not to support usage of `printf(...)` or
 `fprintf(stdout,...)`. Only `write(STDOUT_FILENO,...)` seems to be efficient.
 
-The imput module consume pipes form all external programs in a mono-threaded
+The input module consume pipes form all external programs in a mono-threaded
 `runInput` method. This means that data treatments will be serialized.
 
 Optionally, the module manage the external program through keyword sent to

--- a/source/configuration/modules/imptcp.rst
+++ b/source/configuration/modules/imptcp.rst
@@ -12,7 +12,7 @@ Purpose
 =======
 
 Provides the ability to receive syslog messages via plain TCP syslog.
-This is a specialised input plugin tailored for high performance on
+This is a specialized input plugin tailored for high performance on
 Linux. It will probably not run on any other platform. Also, it does not
 provide TLS services. Encryption can be provided by using
 `stunnel <rsyslog_stunnel.html>`_.
@@ -550,7 +550,7 @@ MultiLine
 
    "binary", "off", "no", "none"
 
-Experimental parameter which causes rsyslog to recognise a new message
+Experimental parameter which causes rsyslog to recognize a new message
 only if the line feed is followed by a '<' or if there are no more characters.
 
 

--- a/source/configuration/modules/imrelp.rst
+++ b/source/configuration/modules/imrelp.rst
@@ -420,7 +420,7 @@ KeepAlive
    "binary", "off", "no", "none"
 
 Enable or disable keep-alive packets at the TCP socket layer. By 
-defauly keep-alives are disabled.
+default keep-alives are disabled.
 
 
 KeepAlive.Probes
@@ -521,7 +521,7 @@ unresponsive if you change flowcontrol to "full"**. While this may be a
 desired effect when intentionally trying to make it most unlikely that 
 rsyslog needs to lose/discard messages, usually this is not what you want.
 
-General rule of thumb: **if you do not fully understand what this decription
+General rule of thumb: **if you do not fully understand what this description
 here talks about, leave the parameter at default value**.
 
 This part of the

--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -475,7 +475,7 @@ PreserveCase
 
 .. versionadded:: 8.37.0
 
-This parameter is for controlling the case in fromhost.  If preservecase is set to "off", the case in fromhost is not preserved.  E.g., 'host1.example.org' the message was received from 'Host1.Example.Org'.  Default to "on" for the backword compatibility.
+This parameter is for controlling the case in fromhost.  If preservecase is set to "off", the case in fromhost is not preserved.  E.g., 'host1.example.org' the message was received from 'Host1.Example.Org'.  Default to "on" for the backward compatibility.
 
 
 Input Parameters
@@ -492,7 +492,7 @@ Port
    "string", "none", "yes", "``$InputTCPServerRun``"
 
 Starts a TCP server on selected port. If port zero is selected, the OS automatically
-assigens a free port. Use `listenPortFileName` in this case to obtain the information
+assigns a free port. Use `listenPortFileName` in this case to obtain the information
 of which port was assigned.
 
 

--- a/source/configuration/modules/imudp.rst
+++ b/source/configuration/modules/imudp.rst
@@ -161,7 +161,7 @@ PreserveCase
 
 .. versionadded:: 8.37.0
 
-This parameter is for controlling the case in fromhost.  If preservecase is set to "on", the case in fromhost is preserved.  E.g., 'Host1.Example.Org' when the message was received from 'Host1.Example.Org'.  Default to "off" for the backword compatibility.
+This parameter is for controlling the case in fromhost.  If preservecase is set to "on", the case in fromhost is preserved.  E.g., 'Host1.Example.Org' when the message was received from 'Host1.Example.Org'.  Default to "off" for the backward compatibility.
 
 
 .. index:: imudp; input parameters
@@ -402,7 +402,7 @@ listener IP, a colon and port in parenthesis. For example, the counter for a
 listener on port 514 (on all IPs) with no set name is called "imudp(\*:514)".
 
 If an "inputname" is defined for a listener, that inputname is used instead of
-"imudp" as statistic name. For example, if the inputname is set to "myudpinut",
+"imudp" as statistic name. For example, if the inputname is set to "myudpinput",
 that corresponding statistic name in above case would be "myudpinput(\*:514)".
 This has been introduced in 7.5.3.
 

--- a/source/configuration/modules/mmanon.rst
+++ b/source/configuration/modules/mmanon.rst
@@ -111,7 +111,7 @@ the right, so lower bits are anonymized first). This setting permits
 to save network information while still anonymizing user-specific
 data. The more bits you discard, the better the anonymization
 obviously is. The default of 16 bits reflects what German data
-privacy rules consider as being sufficinetly anonymized. We assume,
+privacy rules consider as being sufficiently anonymized. We assume,
 this can also be used as a rough but conservative guideline for other
 countries.
 Note: when in simple mode, only bits on a byte boundary can be
@@ -173,7 +173,7 @@ The default "zero" mode will do full anonymization of any number
 of bits and it will also normalize the address, so that no information
 about the original IP address is available.
 
-Also note that an anonymmized IPv6 address will be normalized, meaning
+Also note that an anonymized IPv6 address will be normalized, meaning
 there will be no abbreviations, leading zeros will **not** be displayed,
 and capital letters in the hex numerals will be lowercase.
 
@@ -193,7 +193,7 @@ the right, so lower bits are anonymized first). This setting permits
 to save network information while still anonymizing user-specific
 data. The more bits you discard, the better the anonymization
 obviously is. The default of 96 bits reflects what German data
-privacy rules consider as being sufficinetly anonymized. We assume,
+privacy rules consider as being sufficiently anonymized. We assume,
 this can also be used as a rough but conservative guideline for other
 countries.
 
@@ -234,7 +234,7 @@ The default "zero" mode will do full anonymization of any number
 of bits and it will also normalize the address, so that no information
 about the original IP address is available.
 
-Also note that an anonymmized IPv6 address will be normalized, meaning
+Also note that an anonymized IPv6 address will be normalized, meaning
 there will be no abbreviations, leading zeros will **not** be displayed,
 and capital letters in the hex numerals will be lowercase.
 
@@ -254,7 +254,7 @@ the right, so lower bits are anonymized first). This setting permits
 to save network information while still anonymizing user-specific
 data. The more bits you discard, the better the anonymization
 obviously is. The default of 96 bits reflects what German data
-privacy rules consider as being sufficinetly anonymized. We assume,
+privacy rules consider as being sufficiently anonymized. We assume,
 this can also be used as a rough but conservative guideline for other
 countries.
 
@@ -358,7 +358,7 @@ Anonymizing only ipv6 addresses
 -------------------------------
 
 Another option is to only anonymize IPv6 addresses. When doing this you have to
-disable IPv4 aonymization. This example will lead to only IPv6 addresses anonymized
+disable IPv4 anonymization. This example will lead to only IPv6 addresses anonymized
 (using the random-consistent mode).
 
 .. code-block:: none

--- a/source/configuration/modules/mmjsonparse.rst
+++ b/source/configuration/modules/mmjsonparse.rst
@@ -23,7 +23,7 @@ will be created and the "msg" field will be the only field and it will
 contain the message. Note that in this case, mmjsonparse will
 nonetheless return that the JSON parsing has failed.
 
-The "CEE cookie" is the character squence "@cee:" which must prepend the
+The "CEE cookie" is the character sequence "@cee:" which must prepend the
 actual JSON. Note that the JSON must be valid and MUST NOT be followed
 by any non-JSON message. If either of these conditions is not true,
 mmjsonparse will **not** parse the associated JSON. This is based on the

--- a/source/configuration/modules/mmnormalize.rst
+++ b/source/configuration/modules/mmnormalize.rst
@@ -88,7 +88,7 @@ Note: parameter names are case-insensitive.
 
    *(Available since: 8.5.1)*
 
-   Specifies if a variable insteed of property 'msg' should be used for
+   Specifies if a variable instead of property 'msg' should be used for
    normalization. A variable can be property, local variable, json-path etc.
    Please note that **useRawMsg** overrides this parameter, so if **useRawMsg**
    is set, **variable** will be ignored and raw message will be used.

--- a/source/configuration/modules/mmpstrucdata.rst
+++ b/source/configuration/modules/mmpstrucdata.rst
@@ -21,7 +21,7 @@ Currently none.
 
  
 
-**Action Confguration Parameters**:
+**Action Configuration Parameters**:
 
 Note: parameter names are case-insensitive.
 

--- a/source/configuration/modules/mmrfc5424addhmac.rst
+++ b/source/configuration/modules/mmrfc5424addhmac.rst
@@ -33,7 +33,7 @@ Currently none.
 
  
 
-**Action Confguration Parameters**:
+**Action Configuration Parameters**:
 
 Note: parameter names are case-insensitive.
 

--- a/source/configuration/modules/mmtaghostname.rst
+++ b/source/configuration/modules/mmtaghostname.rst
@@ -74,7 +74,7 @@ Sample
 ======
 
 In this sample, the message received is parsed by RFC5424 parser and then 
-the HOSTNAME is overwritten and a tag is setted. 
+the HOSTNAME is overwritten and a tag is set. 
 
 .. code-block:: none
 

--- a/source/configuration/modules/mmutf8fix.rst
+++ b/source/configuration/modules/mmutf8fix.rst
@@ -53,7 +53,7 @@ Currently none.
 
  
 
-**Action Confguration Parameters**:
+**Action Configuration Parameters**:
 
 Note: parameter names are case-insensitive.
 

--- a/source/configuration/modules/omdtls.rst
+++ b/source/configuration/modules/omdtls.rst
@@ -241,8 +241,8 @@ The following sample does the following:
    action(type="omdtls" name="omdtls" target="192.168.2.1" port="4433")
 
 
-Example 2: Message throttleling
-------------------------------------
+Example 2: Message throttling
+-----------------------------
 
 The following sample does the following:
 

--- a/source/configuration/modules/omfile.rst
+++ b/source/configuration/modules/omfile.rst
@@ -380,7 +380,7 @@ dynaFileCacheSize
    "integer", "10", "no", "``$DynaFileCacheSize``"
 
 This parameter specifies the maximum size of the cache for
-dynamically-generated file names (dynafile= parmeter).
+dynamically-generated file names (dynafile= parameter).
 This setting specifies how many open file handles should
 be cached. If, for example, the file name is generated with the hostname
 in it and you have 100 different hosts, a cache size of 100 would ensure

--- a/source/configuration/modules/omhiredis.rst
+++ b/source/configuration/modules/omhiredis.rst
@@ -719,8 +719,8 @@ Example 9: Ensuring streams don't grow indefinitely
 ---------------------------------------------------
 
 | While using Redis streams, index entries are not automatically evicted, even if you acknowledge entries.
-| You have several options to ensure your streams stays under reasonable memoyr usage, while making sure your data is
- not evicted before behing processed.
+| You have several options to ensure your streams stays under reasonable memory usage, while making sure your data is
+ not evicted before being processed.
 | To do that, you have 2 available options, that can be used independently from each other
  (as they don't apply to the same source):
 

--- a/source/configuration/modules/omhttp.rst
+++ b/source/configuration/modules/omhttp.rst
@@ -326,21 +326,21 @@ Each message on the "Inputs" line is the templated log line that is fed into the
     Inputs: "message 1" "message 2" "message 3"
     Output: "message 1\nmessage2\nmessage3"
 
-2. *jsonarray* - Builds a JSON array containing all messages in the batch. This mode requires that each message is parseable JSON, since the plugin parses each message as JSON while building the array.
+2. *jsonarray* - Builds a JSON array containing all messages in the batch. This mode requires that each message is parsable JSON, since the plugin parses each message as JSON while building the array.
 
 .. code-block:: text
 
     Inputs: {"msg": "message 1"} {"msg"": "message 2"} {"msg": "message 3"}
     Output: [{"msg": "message 1"}, {"msg"": "message 2"}, {"msg": "message 3"}]
 
-3. *kafkarest* - Builds a JSON object that conforms to the `Kafka Rest Proxy specification <https://docs.confluent.io/current/kafka-rest/docs/quickstart.html>`_. This mode requires that each message is parseable JSON, since the plugin parses each message as JSON while building the batch object.
+3. *kafkarest* - Builds a JSON object that conforms to the `Kafka Rest Proxy specification <https://docs.confluent.io/current/kafka-rest/docs/quickstart.html>`_. This mode requires that each message is parsable JSON, since the plugin parses each message as JSON while building the batch object.
 
 .. code-block:: text
 
     Inputs: {"msg": "message 1"} {"msg"": "message 2"} {"msg": "message 3"}
     Output: {"records": [{"value": {"msg": "message 1"}}, {"value": {"msg": "message 2"}}, {"value": {"msg": "message 3"}}]}
 
-4. *lokirest* - Builds a JSON object that conforms to the `Loki Rest specification <https://github.com/grafana/loki/blob/master/docs/api.md#post-lokiapiv1push>`_. This mode requires that each message is parseable JSON, since the plugin parses each message as JSON while building the batch object. Additionally, the operator is responsible for providing index keys, and message values.
+4. *lokirest* - Builds a JSON object that conforms to the `Loki Rest specification <https://github.com/grafana/loki/blob/master/docs/api.md#post-lokiapiv1push>`_. This mode requires that each message is parsable JSON, since the plugin parses each message as JSON while building the batch object. Additionally, the operator is responsible for providing index keys, and message values.
 
 .. code-block:: text
 

--- a/source/configuration/modules/omoracle.rst
+++ b/source/configuration/modules/omoracle.rst
@@ -32,7 +32,7 @@ From the header comments of this module:
 
 
         This is an output module feeding directly to an Oracle
-        database. It uses Oracle Call Interface, a propietary module
+        database. It uses Oracle Call Interface, a proprietary module
         provided by Oracle.
 
         Selector lines to be used are of this form:
@@ -83,7 +83,7 @@ Some additional documentation contributed by Ronny Egner:
 
     - Oracle Instantclient 10g (NOT 11g) Base + Devel
       (if you´re on 64-bit linux you should choose the 64-bit libs!) 
-    - JDK 1.6 (not neccessary for oracle plugin but "make" didd not finsished successfully without it)
+    - JDK 1.6 (not necessary for oracle plugin but "make" didd not finsished successfully without it)
 
     - "oracle-instantclient-config" script 
       (seems to shipped with instantclient 10g Release 1 but i was unable to find it for 10g Release 2 so here it is)

--- a/source/configuration/modules/omrabbitmq.rst
+++ b/source/configuration/modules/omrabbitmq.rst
@@ -241,7 +241,7 @@ populate\_properties
 
   "binary", "no", , "off"
 
-fill timestamp, appid, msgid, hostname (custom header) with message informations
+fill timestamp, appid, msgid, hostname (custom header) with message information
 
 content\_type
 ^^^^^^^^^^^^^

--- a/source/configuration/modules/pmdb2diag.rst
+++ b/source/configuration/modules/pmdb2diag.rst
@@ -15,7 +15,7 @@ The objective of this module is to extract timestamp, procid and appname form th
 lines without altering it
 
 The parser is acting after an imfile input. This implies that imfile must be configured
-with needParse to setted to on.
+with needParse to set to on.
 
 Compile
 =======

--- a/source/configuration/modules/pmlastmsg.rst
+++ b/source/configuration/modules/pmlastmsg.rst
@@ -21,7 +21,7 @@ reason is that some processing overhead is involved in processing these
 messages (they must be recognized) and we would not like to place this
 toll on every user but only on those actually in need of the feature.
 Note that the performance toll is not large -- but if you expect a very
-high message rate with tenthousands of messages per second, you will
+high message rate with ten thousands of messages per second, you will
 notice a difference.
 
 This module should be loaded first inside :doc:`rsyslog's parser

--- a/source/configuration/modules/sigprov_gt.rst
+++ b/source/configuration/modules/sigprov_gt.rst
@@ -62,8 +62,8 @@ both in order to prove integrity.
 -  **sig.keepTreeHashes** <on/**off**>
    Controls if tree (intermediate) hashes are written to the .gtsig
    file. This enhances the ability to spot the location of a signature
-   breach, but costs considerable disk space (a bit mire than the amount
-   sig.keepRecordHashes requries). Note that both Tree and Record hashes
+   breach, but costs considerable disk space (a bit more than the amount
+   sig.keepRecordHashes requires). Note that both Tree and Record hashes
    can be kept inside the signature file.
 
 **See Also**

--- a/source/configuration/modules/sigprov_ksi.rst
+++ b/source/configuration/modules/sigprov_ksi.rst
@@ -69,8 +69,8 @@ both in order to prove integrity.
 -  **sig.keepTreeHashes** <on/**off**>
    Controls if tree (intermediate) hashes are written to the .gtsig
    file. This enhances the ability to spot the location of a signature
-   breach, but costs considerable disk space (a bit mire than the amount
-   sig.keepRecordHashes requries). Note that both Tree and Record hashes
+   breach, but costs considerable disk space (a bit more than the amount
+   sig.keepRecordHashes requires). Note that both Tree and Record hashes
    can be kept inside the signature file.
 
 **See Also**

--- a/source/configuration/templates.rst
+++ b/source/configuration/templates.rst
@@ -205,7 +205,7 @@ property or modifying it. It supports the following parameters:
    that inside string templates, the option must include what it applies
    to whereas with the explicit format that is part of the parameter name.
 
-   To create a customised format you can use multiple property options
+   To create a customized format you can use multiple property options
    together. The following example would result in **YYYY-MM-DD**:
 
 .. code-block:: none

--- a/source/configuration/timezone.rst
+++ b/source/configuration/timezone.rst
@@ -60,7 +60,7 @@ The next sample defines some common timezones:
 
   timezone(id="CET" offset="+01:00")
   timezone(id="CEST" offset="+02:00")
-  timezone(id="METDST" offset="+02:00") # duplicate to support differnt formats
+  timezone(id="METDST" offset="+02:00") # duplicate to support different formats
   timezone(id="EST" offset="-05:00")
   timezone(id="EDT" offset="-04:00")
   timezone(id="PST" offset="-08:00")

--- a/source/includes/substitution_definitions.inc.rst
+++ b/source/includes/substitution_definitions.inc.rst
@@ -1,7 +1,7 @@
 
 ..
   This file is included by the common header file, which is itself
-  included by means of the rst_prolog Sphinx build confiugration
+  included by means of the rst_prolog Sphinx build configuration
   file (source/conf.py). Add substitutions here instead of directly to
   the rst_prolog configuration option.
 

--- a/source/proposals/lookup_tables.rst
+++ b/source/proposals/lookup_tables.rst
@@ -106,7 +106,7 @@ Parameters
 
    Defines the name of lookup table for further reference inside the
    configuration. Names must be unique. Note that it is possible, though
-   not advisible, to have different names for the same file.
+   not advisable, to have different names for the same file.
 -  **file** (mandatory)
 
    Specifies the full path for the lookup table file. This file must be

--- a/source/rainerscript/control_structures.rst
+++ b/source/rainerscript/control_structures.rst
@@ -95,7 +95,7 @@ Here is an example of a nested foreach statement:
       }
    }
 
-Again, the itereted items must have been created by parsing JSON.
+Again, the iterated items must have been created by parsing JSON.
 
 Please note that asynchronous-action calls in foreach-statement body should
 almost always set ``action.copyMsg`` to ``on``. This is because action calls

--- a/source/rainerscript/functions/rs-exists.rst
+++ b/source/rainerscript/functions/rs-exists.rst
@@ -14,7 +14,7 @@ on unset does also not exist.
 The function accepts a single argument, which needs to be a variable.
 It returns 0 if the variable does not exist and 1 otherwise. The
 function can be combined with any other expression to form more
-complec expressions.
+complex expressions.
 
 .. versionadded:: 8.2010.10
 

--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -522,7 +522,7 @@ The following parameters can be set:
 
 - **abortOnFailedQueueStartup** [boolean (on/off)] available 8.2210.0+
 
-  This parameter is similiar to *abortOnUncleanConfig* but makes rsyslog
+  This parameter is similar to *abortOnUncleanConfig* but makes rsyslog
   abort when there are any problems with queue startup. This is usually
   caused by disk queue settings or disk queue file corruption. Normally,
   rsyslog ignores disk queue definitions in this case and switches the
@@ -585,7 +585,7 @@ The following parameters can be set:
   a name ID lookup fails (for user and group names) rsyslog does not start but
   terminate with an error message. This is necessary as a security
   measure, as otherwise the wrong permissions can be assigned or privileges
-  are not dropped. This setting is applied whereever security IDs are resolved,
+  are not dropped. This setting is applied wherever security IDs are resolved,
   e.g. when dropping privileges or assigning file permissions or owners.
 
   The setting should be at the top of the configuration parameters to make sure its
@@ -669,7 +669,7 @@ The following parameters can be set:
   re-enqueue messages stems back to some failed operations. Note that the maximum
   permitted queue size is doubled, as this ensures in all cases that re-enqueuing
   can be completed. Note also that the increase of the max size is temporary during
-  shutdown and also does not requiere any more storage. Except, of course, for
+  shutdown and also does not require any more storage. Except, of course, for
   re-enqueued message.
 
   The situation addressed by this setting is unlikely to happen, but it could happen.

--- a/source/rainerscript/queue_parameters.rst
+++ b/source/rainerscript/queue_parameters.rst
@@ -469,7 +469,7 @@ In some other words, you can consider this scenario, using default values.
 With all progress blocked (unable to deliver a message):
 
 * all delayable inputs (tcp, relp, imfile, imjournal, etc) will block
-  indefinantly (assuming queue.lightdelaymark and queue.fulldelaymark
+  indefinitely (assuming queue.lightdelaymark and queue.fulldelaymark
   are set sensible, which they are by default).
 * imudp will be loosing messages because the OS will be dropping them
 * messages arriving via UDP or imuxsock that do make it to rsyslog,

--- a/source/tutorials/high_database_rate.rst
+++ b/source/tutorials/high_database_rate.rst
@@ -64,7 +64,7 @@ transparently by rsyslog.
 With our above scenario, the disk buffer would build up during the day
 and rsyslog would use the night to drain it. Obviously, this is an
 extreme example, but it shows what can be done. Please note that queue
-content survies rsyslogd restarts, so even a reboot of the system will
+content survives rsyslogd restarts, so even a reboot of the system will
 not cause any message loss.
 
 How To Setup
@@ -83,7 +83,7 @@ to a MySQL database and have buffering applied automatically.
     module(load="imudp")
     input(type="imudp" port="514")
     
-    # Make sure this path exists and the user of the deamon has read/write/execute access
+    # Make sure this path exists and the user of the daemon has read/write/execute access
     global(WorkDirectory="/var/spool/rsyslog") # default location for work (spool) files
     main_queue(queue.fileName="mainq")
 
@@ -119,7 +119,7 @@ more commands:
     module(load="imudp")
     input(type="imudp" port="514")
     
-    # Make sure this path exists and the user of the deamon has read/write/execute access
+    # Make sure this path exists and the user of the daemon has read/write/execute access
     global(WorkDirectory="/var/spool/rsyslog") # default location for work (spool) files
     
     module (load="ommysql")

--- a/source/whitepapers/syslog_parsing.rst
+++ b/source/whitepapers/syslog_parsing.rst
@@ -39,7 +39,7 @@ informationally described in RFC3164, Section 4. But it demands it only
 for the scope of RFC3195, which is syslog over BEEP - and NOT syslog
 over UDP. So one may argue whether or not the RFC3164 format could be
 considered a standard for any non-BEEP (including UDP) syslog, too. In
-the strict view I tend to have, it does not. Refering to the RFC3195
+the strict view I tend to have, it does not. Referring to the RFC3195
 context usually does not help, because there are virtually no RFC3195
 implementations available (at this time, I would consider this RFC a
 failure).
@@ -161,7 +161,7 @@ but don't expect me to program a parser that is smarter than me.
 To the best of my knowledge, these vendor's device's syslog format can
 be configured, so it would probably be a good idea to include a
 (sufficiently well-formed) timestamp, the sending hostname and (maybe?)
-a tag to make this message well parseable. I will also once again take
+a tag to make this message well parsable. I will also once again take
 this sample and see if we can apply some guesswork. For example, "[" can
 not be part of a well-formed TIMESTAMP, so logic can conclude there is
 not TIMESTAMP. Also, "[" can not be used inside a valid hostname, so

--- a/source/whitepapers/syslog_protocol.rst
+++ b/source/whitepapers/syslog_protocol.rst
@@ -192,8 +192,8 @@ This lists what has been found during implementation:
 
  
 
-Conlusions/Suggestions
-----------------------
+Conclusions/Suggestions
+-----------------------
 
 These are my personal conclusions and suggestions. Obviously, they must
 be discussed ;)


### PR DESCRIPTION
Again, notice some words that don't look correct. Beside that i changed some British English words to the American English form, like `specialised` to `specialized`, as American English forms seems a little bit more common in the rsyslog docs.