### PR TITLE
Fix URLs

### DIFF
--- a/BUILDS_README.md
+++ b/BUILDS_README.md
@@ -43,7 +43,7 @@ steps in this document.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Clone the https://github.com/rsyslog-doc.git repo
+1. Clone the https://github.com/rsyslog/rsyslog-doc.git repo
 1. Merge `master` into the current stable branch (e.g., `v8-stable`)
 1. Tag the stable branch
 1. Push all changes to the remote
@@ -105,7 +105,7 @@ is not already installed and known to your installation of Python.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Run `git clone https://github.com/rsyslog-doc.git`
+1. Run `git clone https://github.com/rsyslog/rsyslog-doc.git`
 1. Run `git checkout v8.33.0`
 1. Run `sphinx -D version="8.33" release="8.33.0" -b html source build`
 
@@ -156,7 +156,7 @@ and is useful to identify a dev build from a release set of documentation.
 1. Review the [`README.md`](README.md) file for instructions that cover
    installing `pip`, setting up the virtual environment and installing
    the latest version of the Sphinx package.
-1. Run `git clone https://github.com/rsyslog-doc.git`
+1. Run `git clone https://github.com/rsyslog/rsyslog-doc.git`
 1. Run `git checkout master`
 1. Run `sphinx -b html source build` to generate HTML format and
    `sphinx -b epub source build` to build an epub file.

--- a/source/community.rst
+++ b/source/community.rst
@@ -23,7 +23,7 @@ interested in the "backstage", you may find
 `Rainer <https://rainer.gerhards.net/>`_'s
 `blog <https://rainer.gerhards.net/>`_ an interesting read (filter on
 syslog and rsyslog tags). Or meet `Rainer Gerhards at
-Facebook <http://www.facebook.com/people/Rainer-Gerhards/1349393098>`_.
+Facebook <https://www.facebook.com/rainer.gerhards.1/>`_.
 If you would like to use rsyslog source code inside your open source
 project, you can do that without any restriction as long as your license
 is GPLv3 compatible. If your license is incompatible to GPLv3, you may

--- a/source/compatibility/v3compatibility.rst
+++ b/source/compatibility/v3compatibility.rst
@@ -1,7 +1,7 @@
 Compatibility Notes for rsyslog v3
 ==================================
 
-*Written by* `Rainer Gerhards <http://www.gerhards.net/rainer>`_
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_
 *(2008-03-28)*
 
 Rsyslog aims to be a drop-in replacement for sysklogd. However, version

--- a/source/compatibility/v4compatibility.rst
+++ b/source/compatibility/v4compatibility.rst
@@ -1,7 +1,7 @@
 Compatibility Notes for rsyslog v4
 ==================================
 
-*Written by* `Rainer Gerhards <http://www.gerhards.net/rainer>`_
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_
 *(2009-07-15)*
 
 The changes introduced in rsyslog v4 are numerous, but not very

--- a/source/compatibility/v5compatibility.rst
+++ b/source/compatibility/v5compatibility.rst
@@ -1,7 +1,7 @@
 Compatibility Notes for rsyslog v5
 ==================================
 
-*Written by* `Rainer Gerhards <http://www.gerhards.net/rainer>`_
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_
 *(2009-07-15)*
 
 The changes introduced in rsyslog v5 are numerous, but not very

--- a/source/concepts/messageparser.rst
+++ b/source/concepts/messageparser.rst
@@ -1,7 +1,7 @@
 Message parsers in rsyslog
 ==========================
 
-Written by `Rainer Gerhards <http://www.gerhards.net/rainer>`_
+Written by `Rainer Gerhards <https://rainer.gerhards.net/>`_
 (2009-11-06)
 
 Intro
@@ -30,7 +30,7 @@ contributing something back to the project.
 But that doesn't answer what a message parser really is. What does it
 mean to "parse a message" and, maybe more importantly, what is a
 message? To answer these questions correctly, we need to dig down into
-the relevant standards. `RFC5424 <http://tools.ietf.org/html/rfc5424>`_
+the relevant standards. `RFC5424 <https://datatracker.ietf.org/doc/html/rfc5424>`_
 specifies a layered architecture for the syslog protocol:
 
 .. figure:: rfc5424layers.png
@@ -53,7 +53,7 @@ no two messages can travel within a single UDP packet). In "plain tcp
 syslog", the industry standard, LF is used as a frame delimiter (which
 also means that no multi-line message can properly be transmitted, a
 "design" flaw in plain tcp syslog). In
-`RFC5425 <http://tools.ietf.org/html/rfc5425>`_ there is a header in
+`RFC5425 <https://datatracker.ietf.org/doc/html/rfc5425>`_ there is a header in
 front of each frame that contains the size of the message. With this
 framing, any message content can properly be transferred.
 
@@ -263,7 +263,7 @@ Which message parsers are available
 
 As of this writing, there exist only two message parsers, one for
 RFC5424 format and one for legacy syslog (loosely described in
-`RFC3164 <http://tools.ietf.org/html/rfc3164>`_). These parsers are
+`RFC3164 <https://datatracker.ietf.org/doc/html/rfc3164>`_). These parsers are
 built-in and must not be explicitly loaded. However, message parsers can
 be added with relative ease by anyone knowing to code in C. Then, they
 can be loaded via $ModLoad just like any other loadable module. It is

--- a/source/configuration/modules/imdtls.rst
+++ b/source/configuration/modules/imdtls.rst
@@ -195,7 +195,7 @@ Used to pass additional OpenSSL configuration commands. This can be used to fine
 settings by passing configuration commands to the openssl libray.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
-https://www.openssl.org/docs/man1.0.2/man3/SSL_CONF_cmd.html
+https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
 
 The setting can be single or multiline, each configuration command is separated by linefeed (\n).
 Command and value are separated by equal sign (=). Here are a few samples:

--- a/source/configuration/modules/imhiredis.rst
+++ b/source/configuration/modules/imhiredis.rst
@@ -15,7 +15,7 @@ Purpose
 =======
 
 Imhiredis is an input module reading arbitrary entries from Redis.
-It uses the `hiredis library <https://github.com/redis/hiredis.git>`_ to query Redis instances using 3 modes:
+It uses the `hiredis library <https://github.com/redis/hiredis>`_ to query Redis instances using 3 modes:
 
 - **queues**, using `LIST <https://redis.io/commands#list>`_ commands
 - **channels**, using `SUBSCRIBE <https://redis.io/commands#pubsub>`_ commands

--- a/source/configuration/modules/imhttp.rst
+++ b/source/configuration/modules/imhttp.rst
@@ -161,7 +161,7 @@ SupportOctetCountedFraming
 
    "binary", "no", "", "off"
 
-Useful to send data using syslog style message framing, disabled by default. Message framing is described by `RFC 6587 <https://tools.ietf.org/html/rfc6587#section-3.4.1>`_ .
+Useful to send data using syslog style message framing, disabled by default. Message framing is described by `RFC 6587 <https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1>`_ .
 
 
 RateLimit.Interval

--- a/source/configuration/modules/immark.rst
+++ b/source/configuration/modules/immark.rst
@@ -4,7 +4,7 @@ immark: Mark Message Input Module
 
 ===========================  ===========================================================================
 **Module Name:**             **immark**
-**Author:**                  `Rainer Gerhards <http://www.gerhards.net/rainer>`_ <rgerhards@adiscon.com>
+**Author:**                  `Rainer Gerhards <https://rainer.gerhards.net/>`_ <rgerhards@adiscon.com>
 ===========================  ===========================================================================
 
 Purpose

--- a/source/configuration/modules/impcap.rst
+++ b/source/configuration/modules/impcap.rst
@@ -112,7 +112,7 @@ file
    "word", "none", "no", "none"
 
 This parameter specifies a pcap file to read.
-The file must respect the `pcap file format specification <https://www.tcpdump.org/pcap/pcap.html>`_. **If 'file' is not specified, 'interface' must be in order
+The file must respect the `pcap file format specification <https://www.tcpdump.org/manpages/pcap-savefile.5.html>`_. **If 'file' is not specified, 'interface' must be in order
 for the module to run.**
 
 .. Warning::

--- a/source/configuration/modules/imrelp.rst
+++ b/source/configuration/modules/imrelp.rst
@@ -382,7 +382,7 @@ The setting can be used if tls.tlslib is set to "openssl" to pass configuration 
 the openssl libray.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
-https://www.openssl.org/docs/man1.0.2/man3/SSL_CONF_cmd.html
+https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
 
 The setting can be single or multiline, each configuration command is separated by linefeed (\n).
 Command and value are separated by equal sign (=). Here are a few samples:

--- a/source/configuration/modules/imtcp.rst
+++ b/source/configuration/modules/imtcp.rst
@@ -355,7 +355,7 @@ Specifies the allowed maximum depth for the certificate chain verification.
 Support added in v8.2001.0, supported by GTLS and OpenSSL driver.
 If not set, the API default will be used. 
 For OpenSSL, the default is 100 - see the doc for more:
-https://www.openssl.org/docs/man1.1.1/man3/SSL_set_verify_depth.html
+https://docs.openssl.org/1.1.1/man3/SSL_CTX_set_verify/
 For GnuTLS, the default is 5 - see the doc for more:
 https://www.gnutls.org/manual/gnutls.html
 
@@ -434,7 +434,7 @@ In GNUTLS, this setting determines the handshake algorithms and options for the 
 
 **OpenSSL Configuration**
 
-This feature is compatible with OpenSSL Version 1.0.2 and above. It enables the passing of configuration commands to the OpenSSL library. You can find a comprehensive list of commands and their acceptable values in the OpenSSL Documentation, accessible at [OpenSSL Documentation](https://www.openssl.org/docs/man1.0.2/man3/SSL_CONF_cmd.html).
+This feature is compatible with OpenSSL Version 1.0.2 and above. It enables the passing of configuration commands to the OpenSSL library. You can find a comprehensive list of commands and their acceptable values in the OpenSSL Documentation, accessible at [OpenSSL Documentation](https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/).
 
 **General Configuration Guidelines**
 

--- a/source/configuration/modules/imuxsock.rst
+++ b/source/configuration/modules/imuxsock.rst
@@ -4,7 +4,7 @@ imuxsock: Unix Socket Input Module
 
 ===========================  ===========================================================================
 **Module Name:**             **imuxsock**
-**Author:**                  `Rainer Gerhards <http://www.gerhards.net/rainer>`_ <rgerhards@adiscon.com>
+**Author:**                  `Rainer Gerhards <https://rainer.gerhards.net/>`_ <rgerhards@adiscon.com>
 ===========================  ===========================================================================
 
 

--- a/source/configuration/modules/mmanon.rst
+++ b/source/configuration/modules/mmanon.rst
@@ -19,7 +19,7 @@ obtained. Note that anonymization will break digital signatures on the
 message, if they exist.
 
 Please note that log files can also be anonymized via
-`SLFA <http://jan.gerhards.net/p/slfa.html>`_ after they
+`SLFA <https://jan.gerhards.net/2017/10/12/slfa-release/>`_ after they
 have been created.
 
 *How are IP-Addresses defined?*

--- a/source/configuration/modules/mmpstrucdata.rst
+++ b/source/configuration/modules/mmpstrucdata.rst
@@ -9,7 +9,7 @@ RFC5424 structured data parsing module (mmpstrucdata)
 
 **Description**:
 
-The mmpstrucdata parses the structured data of `RFC5424 <https://tools.ietf.org/html/rfc5424>`_ into the message json variable tree. The data parsed, if available, is stored under "jsonRoot!rfc5424-sd!...". Please note that only RFC5424 messages will be processed.
+The mmpstrucdata parses the structured data of `RFC5424 <https://datatracker.ietf.org/doc/html/rfc5424>`_ into the message json variable tree. The data parsed, if available, is stored under "jsonRoot!rfc5424-sd!...". Please note that only RFC5424 messages will be processed.
 
 The difference of RFC5424 is in the message layout: the SYSLOG-MSG part only contains the structured-data part instead of the normal message part. Further down you can find a example of a structured-data part.
 

--- a/source/configuration/modules/omdtls.rst
+++ b/source/configuration/modules/omdtls.rst
@@ -163,7 +163,7 @@ Used to pass additional OpenSSL configuration commands. This can be used to fine
 settings by passing configuration commands to the openssl libray.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
-https://www.openssl.org/docs/man1.0.2/man3/SSL_CONF_cmd.html
+https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
 
 The setting can be single or multiline, each configuration command is separated by linefeed (\n).
 Command and value are separated by equal sign (=). Here are a few samples:

--- a/source/configuration/modules/omfwd.rst
+++ b/source/configuration/modules/omfwd.rst
@@ -638,7 +638,7 @@ Specifies the allowed maximum depth for the certificate chain verification.
 Support added in v8.2001.0, supported by GTLS and OpenSSL driver.
 If not set, the API default will be used.
 For OpenSSL, the default is 100 - see the doc for more:
-https://www.openssl.org/docs/man1.1.1/man3/SSL_set_verify_depth.html
+https://docs.openssl.org/1.1.1/man3/SSL_CTX_set_verify/
 For GnuTLS, the default is 5 - see the doc for more:
 https://www.gnutls.org/manual/gnutls.html
 
@@ -808,7 +808,7 @@ information about priority Strings
 For OpenSSL, the setting can be used to pass configuration commands to openssl library.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
-https://www.openssl.org/docs/man1.0.2/man3/SSL_CONF_cmd.html
+https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
 
 The setting can be single or multiline, each configuration command is separated by linefeed (\n).
 Command and value are separated by equal sign (=). Here are a few samples:

--- a/source/configuration/modules/omhttp.rst
+++ b/source/configuration/modules/omhttp.rst
@@ -35,7 +35,7 @@ Notable Features
 - `Message Batching`_, supports several formats.
     - Newline concatenation, like the Elasticsearch bulk format.
     - JSON Array as a generic batching strategy.
-    - Kafka REST Proxy format, to support sending data through the `Confluent Kafka REST API <https://docs.confluent.io/current/kafka-rest/docs/index.html>`_ to a Kafka cluster.
+    - Kafka REST Proxy format, to support sending data through the `Confluent Kafka REST API <https://docs.confluent.io/platform/current/kafka-rest/index.html>`_ to a Kafka cluster.
 
 Configuration Parameters
 ========================
@@ -333,14 +333,14 @@ Each message on the "Inputs" line is the templated log line that is fed into the
     Inputs: {"msg": "message 1"} {"msg"": "message 2"} {"msg": "message 3"}
     Output: [{"msg": "message 1"}, {"msg"": "message 2"}, {"msg": "message 3"}]
 
-3. *kafkarest* - Builds a JSON object that conforms to the `Kafka Rest Proxy specification <https://docs.confluent.io/current/kafka-rest/docs/quickstart.html>`_. This mode requires that each message is parsable JSON, since the plugin parses each message as JSON while building the batch object.
+3. *kafkarest* - Builds a JSON object that conforms to the `Kafka Rest Proxy specification <https://docs.confluent.io/platform/current/kafka-rest/quickstart.html>`_. This mode requires that each message is parsable JSON, since the plugin parses each message as JSON while building the batch object.
 
 .. code-block:: text
 
     Inputs: {"msg": "message 1"} {"msg"": "message 2"} {"msg": "message 3"}
     Output: {"records": [{"value": {"msg": "message 1"}}, {"value": {"msg": "message 2"}}, {"value": {"msg": "message 3"}}]}
 
-4. *lokirest* - Builds a JSON object that conforms to the `Loki Rest specification <https://github.com/grafana/loki/blob/master/docs/api.md#post-lokiapiv1push>`_. This mode requires that each message is parsable JSON, since the plugin parses each message as JSON while building the batch object. Additionally, the operator is responsible for providing index keys, and message values.
+4. *lokirest* - Builds a JSON object that conforms to the `Loki Rest specification <https://github.com/grafana/loki/blob/main/docs/sources/reference/loki-http-api.md#ingest-logs>`_. This mode requires that each message is parsable JSON, since the plugin parses each message as JSON while building the batch object. Additionally, the operator is responsible for providing index keys, and message values.
 
 .. code-block:: text
 
@@ -489,7 +489,7 @@ Here you can set the name of a file where all errors will be written to. Any req
 
     {
         "request": {
-            "url": "https://url.com:443/path",
+            "url": "https://example.com:443/path",
             "postdata": "mypayload"
         },
         "response" : {

--- a/source/configuration/modules/ommail.rst
+++ b/source/configuration/modules/ommail.rst
@@ -301,6 +301,6 @@ Additional Resources
 A more advanced example plus a discussion on using the email feature
 inside a reliable system can be found in Rainer's blogpost "`Why is
 native email capability an advantage for a
-syslogd? <http://rgerhards.blogspot.com/2008/04/why-is-native-email-capability.html>`_\ "
+syslogd? <https://rainer.gerhards.net/2008/04/why-is-native-email-capability-an-advantage-for-a-syslogd.html>`_\ "
 
 

--- a/source/configuration/modules/omrelp.rst
+++ b/source/configuration/modules/omrelp.rst
@@ -390,7 +390,7 @@ The setting can be used if tls.tlslib is set to "openssl" to pass configuration 
 the openssl libray.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
-https://www.openssl.org/docs/man1.0.2/man3/SSL_CONF_cmd.html
+https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
 
 The setting can be single or multiline, each configuration command is separated by linefeed (\n).
 Command and value are separated by equal sign (=). Here are a few samples:

--- a/source/configuration/modules/omsnmp.rst
+++ b/source/configuration/modules/omsnmp.rst
@@ -122,9 +122,9 @@ In order to decode this OID, you will need to have the
 ADISCON-MONITORWARE-MIB and ADISCON-MIB mibs installed on the
 receiver side. Downloads of these mib files can be found here:
 
-`http://www.adiscon.org/download/ADISCON-MIB.txt <http://www.adiscon.org/download/ADISCON-MIB.txt>`_
+`https://www.adiscon.org/download/ADISCON-MIB.txt <https://www.adiscon.org/download/ADISCON-MIB.txt>`_
 
-`http://www.adiscon.org/download/ADISCON-MONITORWARE-MIB.txt <http://www.adiscon.org/download/ADISCON-MONITORWARE-MIB.txt>`_
+`https://www.adiscon.org/download/ADISCON-MONITORWARE-MIB.txt <https://www.adiscon.org/download/ADISCON-MONITORWARE-MIB.txt>`_
 Thanks to the net-snmp mailinglist for the help and the
 recommendations ;).
 

--- a/source/configuration/property_replacer.rst
+++ b/source/configuration/property_replacer.rst
@@ -197,7 +197,7 @@ options are defined:
 
 **csv**
   formats the resulting field (after all modifications) in CSV format as
-  specified in `RFC 4180 <http://www.ietf.org/rfc/rfc4180.txt>`_. Rsyslog
+  specified in `RFC 4180 <https://datatracker.ietf.org/doc/html/rfc4180>`_. Rsyslog
   will always use double quotes. Note that in order to have full
   CSV-formatted text, you need to define a proper template. An example is
   this one:

--- a/source/configuration/templates.rst
+++ b/source/configuration/templates.rst
@@ -30,7 +30,7 @@ Template processing
 ===================
 
 Due to lack of standardization regarding logs formats, when a template is
-specified it's supposed to include HEADER, as defined in `RFC5424 <https://tools.ietf.org/html/rfc5424>`_
+specified it's supposed to include HEADER, as defined in `RFC5424 <https://datatracker.ietf.org/doc/html/rfc5424>`_
 
 It's very important to have this in mind, and also to understand how
 `rsyslog parsing <http://www.rsyslog.com/doc/syslog_parsing.html>`_ works.
@@ -734,7 +734,7 @@ messages to rsyslog 3.12.5 or above.
 
 **RSYSLOG_SyslogProtocol23Format** - the format specified in IETF's
 internet-draft ietf-syslog-protocol-23, which is very close to the actual
-syslog standard `RFC5424 <https://tools.ietf.org/html/rfc5424>`_ (we couldn't
+syslog standard `RFC5424 <https://datatracker.ietf.org/doc/html/rfc5424>`_ (we couldn't
 update this template as things were in production for quite some time when
 RFC5424 was finally approved). This format includes several improvements.
 You may use this format with all relatively recent versions of rsyslog or syslogd.

--- a/source/development/generic_design.rst
+++ b/source/development/generic_design.rst
@@ -1,7 +1,7 @@
 Generic design of a syslogd
 ---------------------------
 
-Written 2007-04-10 by `Rainer Gerhards <https://rainer.gerhards.net>`_
+Written 2007-04-10 by `Rainer Gerhards <https://rainer.gerhards.net/>`_
 
 The text below describes a generic approach on how a syslogd can be
 implemented. I created this description for some other project, where it

--- a/source/features.rst
+++ b/source/features.rst
@@ -142,7 +142,7 @@ customers to your business!**
    applications. You may also read my blog post on the future of
    liblogging, which contains interesting information about the `future
    of RFC 3195 in
-   rsyslog <http://rgerhards.blogspot.com/2007/09/where-is-liblogging-heading-to.html>`_.
+   rsyslog <https://rainer.gerhards.net/2007/09/where-is-liblogging-heading-to.html>`_.
 
 To see when each feature was added, see the `rsyslog change
 log <http://www.rsyslog.com/Topic4.phtml>`_ (online only).

--- a/source/historical/module_devel.rst
+++ b/source/historical/module_devel.rst
@@ -1,7 +1,7 @@
 Developing rsyslog modules (outdated)
 =====================================
 
-*Written by `Rainer Gerhards* <https://rainer.gerhards.net>`_ *(2007-07-28)*
+*Written by `Rainer Gerhards* <https://rainer.gerhards.net/>`_ *(2007-07-28)*
 
 **This document is outdated and primarily contains historical
 information. Do not trust it to build code. It currently is under

--- a/source/historical/php_syslog_ng.rst
+++ b/source/historical/php_syslog_ng.rst
@@ -1,7 +1,7 @@
 Using php-syslog-ng with rsyslog
 ================================
 
-*Written by* `Rainer Gerhards <https://rainer.gerhards.net>`_ *(2005-08-04)*
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_ *(2005-08-04)*
 
 Note: it has been reported that this guide is somewhat outdated. Most
 importantly, this guide is for the **original** php-syslog-ng and

--- a/source/historical/stunnel.rst
+++ b/source/historical/stunnel.rst
@@ -1,7 +1,7 @@
 SSL Encrypting Syslog with Stunnel
 ==================================
 
-*Written by* `Rainer Gerhards <https://rainer.gerhards.net>`_ *(2005-07-22)*
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_ *(2005-07-22)*
 
 **HISTORICAL DOCUMENT**
 
@@ -53,7 +53,7 @@ Log forwarding). Plain tcp syslog offers reliability, but it does not
 offer encryption in itself. However, since it operates on a tcp stream,
 it is now easy to add encryption. There are various ways to do that. In
 this paper, I will describe how it is done with stunnel (an other
-alternative would be `IPSec <http://en.wikipedia.org/wiki/IPSec>`_, for
+alternative would be `IPsec <https://en.wikipedia.org/wiki/IPsec>`_, for
 example).
 
 Stunnel is open source and it is available both for Unix/Linux and
@@ -77,10 +77,10 @@ what the protocol designers had on their mind ;)
 
 In the rest of this document, I assume that you use rsyslog on both the
 client and the server. For the samples, I use
-`Debian <http://www.debian.org/>`_. Interestingly, there are some
+`Debian <https://www.debian.org/>`_. Interestingly, there are some
 annoying differences between stunnel implementations. For example, on
 Debian a comment line starts with a semicolon (';'). On `Red
-Hat <http://www.redhat.com>`_, it starts with a hash sign ('#'). So you
+Hat <https://www.redhat.com/en>`_, it starts with a hash sign ('#'). So you
 need to watch out for subtle issues when setting up your system.
 
 Overall System Setup

--- a/source/history.rst
+++ b/source/history.rst
@@ -59,7 +59,7 @@ solved (but Rainer likes the idea of a new format), so we need to live
 with it for the time being. It is planned to be reconsidered in the 3.x
 release time frame.
 
-If you are interested in the `IHE <http://en.wikipedia.org/wiki/IHE>`_
+If you are interested in the `IHE <https://en.wikipedia.org/wiki/Integrating_the_Healthcare_Enterprise>`_
 environment, you might be interested to hear that rsyslog supports
 message with sizes of 32k and more. This feature has been tested, but by
 default is turned off (as it has some memory footprint that we didn't
@@ -96,7 +96,7 @@ contributions, we set up a `wiki <http://wiki.rsyslog.com/>`_ on August
 deemed to be quite close to the final 2.0.0 release. With its
 appearance, the pace of changes was deliberately reduced, in order to
 allow it to mature (see Rainers's `blog
-post <http://rgerhards.blogspot.com/2007/07/pace-of-changes-in-rsyslog.html>`_
+post <https://rainer.gerhards.net/2007/07/pace-of-changes-in-rsyslog.html>`_
 on this topic, written a bit early, but covering the essence).
 
 In **November 2007**, rsyslog became the default syslogd in Fedora 8.

--- a/source/installation/install_from_source.rst
+++ b/source/installation/install_from_source.rst
@@ -1,7 +1,7 @@
 Installing rsyslog from Source
 ==============================
 
-*Written by* `Rainer Gerhards <https://rainer.gerhards.net>`_
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_
 
 **In this paper, I describe how to install**
 `rsyslog <http://www.rsyslog.com/>`_. It is intentionally a brief
@@ -170,7 +170,7 @@ both it and rsyslogd listen to the same sockets, they can NOT be run
 concurrently. So you need to disable the stock syslogd. To do this, you
 typically must change your rc.d startup scripts.
 
-For example, under `Debian <http://www.debian.org/>`_ this must be done
+For example, under `Debian <https://www.debian.org/>`_ this must be done
 as follows: The default runlevel is 2. We modify the init scripts for
 runlevel 2 - in practice, you need to do this for all run levels you
 will ever use (which probably means all). Under /etc/rc2.d there is a

--- a/source/proposals/big_restructuring/contributing/community/releases.rst
+++ b/source/proposals/big_restructuring/contributing/community/releases.rst
@@ -39,5 +39,5 @@ finished in time or if it won't be stable enough to be included in the current
 final release.
 
 
-.. _Semantic Versioning: http://semver.org/
+.. _Semantic Versioning: https://semver.org/
 .. _Git repository: https://github.com/rsyslog/rsyslog

--- a/source/proposals/big_restructuring/documentation_review.rst
+++ b/source/proposals/big_restructuring/documentation_review.rst
@@ -59,11 +59,11 @@ Extra
 
 Some resources worth taking a look.
 
-    * https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Viewing_and_Managing_Log_Files.html
+    * https://docs.redhat.com/en/documentation/Red_Hat_Enterprise_Linux/7/html/system_administrators_guide/ch-viewing_and_managing_log_files
 	* https://www.usenix.org/system/files/login/articles/06_lang-online.pdf
-	* https://media.readthedocs.org/pdf/rsyslog/latest/rsyslog.pdf
+	* https://rsyslog.readthedocs.io/_/downloads/en/latest/pdf/
 	* http://download.rsyslog.com/rainerscript2_rsyslog.conf
-	* http://people.redhat.com/pvrabec/rpms/rsyslog/rsyslog-example.conf
+	* https://people.redhat.com/pvrabec/rpms/rsyslog/rsyslog-example.conf
 	* http://www.rsyslog.com/doc/syslog_parsing.html
 
 

--- a/source/tutorials/database.rst
+++ b/source/tutorials/database.rst
@@ -1,7 +1,7 @@
 Writing syslog messages to MariaDB, MySQL, PostgreSQL or any other supported Database
 =====================================================================================
 
-*Written by* \ `Rainer Gerhards <https://rainer.gerhards.net>`_\ *with
+*Written by* \ `Rainer Gerhards <https://rainer.gerhards.net/>`_\ *with
 some additions by Marc Schiffbauer (2008-02-28)*
 
 Abstract

--- a/source/tutorials/high_database_rate.rst
+++ b/source/tutorials/high_database_rate.rst
@@ -1,7 +1,7 @@
 Handling a massive syslog database insert rate with Rsyslog
 ===========================================================
 
-*Written by* `Rainer Gerhards <http://www.gerhards.net/rainer>`_
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_
 *(2008-01-31)*
 
 Abstract

--- a/source/tutorials/recording_pri.rst
+++ b/source/tutorials/recording_pri.rst
@@ -1,7 +1,7 @@
 Recording the Priority of Syslog Messages
 =========================================
 
-*Written by* `Rainer Gerhards <https://rainer.gerhards.net>`_ *(2007-06-18)*
+*Written by* `Rainer Gerhards <https://rainer.gerhards.net/>`_ *(2007-06-18)*
 
 Abstract
 --------

--- a/source/tutorials/tls.rst
+++ b/source/tutorials/tls.rst
@@ -1,7 +1,7 @@
 Encrypting Syslog Traffic with TLS (SSL) [short version]
 ========================================================
 
-*Written by* `Rainer Gerhards  <http://www.gerhards.net/rainer>`_
+*Written by* `Rainer Gerhards  <https://rainer.gerhards.net/>`_
 *(2008-05-06)*
 
 Abstract
@@ -40,13 +40,13 @@ mailing list thread that describes `total loss of syslog messages due to
 stunnel
 mode <http://lists.adiscon.net/pipermail/rsyslog/2008-March/000580.html>`_
 and the `unreliability of TCP
-syslog <http://rgerhards.blogspot.com/2008/04/on-unreliability-of-plain-tcp-syslog.html>`_).
+syslog <https://rainer.gerhards.net/2008/04/on-unreliability-of-plain-tcp-syslog.html>`_).
 
 `Rsyslog supports syslog via GSSAP <gssapi.html>`_\ I since long to
 overcome these limitations. However, syslog via GSSAPI is a
 rsyslog-exclusive transfer mode and it requires a proper Kerberos
 environment. As such, it isn't a really universal solution. The
-`IETF <http://www.ietf.org/>`_ has begun standardizing syslog over plain
+`IETF <https://www.ietf.org/>`_ has begun standardizing syslog over plain
 tcp over TLS for a while now. While I am not fully satisfied with the
 results so far, this obviously has the  potential to become the
 long-term solution. The Internet Draft in question, syslog-transport-tls

--- a/source/tutorials/tls_cert_summary.rst
+++ b/source/tutorials/tls_cert_summary.rst
@@ -1,7 +1,7 @@
 Encrypting Syslog Traffic with TLS (SSL)
 ========================================
 
-Written by `Rainer Gerhards <https://rainer.gerhards.net>`_ (2008-07-03)
+Written by `Rainer Gerhards <https://rainer.gerhards.net/>`_ (2008-07-03)
 
 .. toctree::
    :maxdepth: 1

--- a/source/whitepapers/syslog_parsing.rst
+++ b/source/whitepapers/syslog_parsing.rst
@@ -20,7 +20,7 @@ The syslog protocol has not been standardized until relatively
 recently. The first document "smelling" a bit like a standard is
 :rfc:`3164`, which dates back to August
 2001. The problem is that this document is no real standard. It has
-assigned "informational" status by the `IETF <http://www.ietf.org>`_
+assigned "informational" status by the `IETF <https://www.ietf.org/>`_
 which means it provides some hopefully useful information but does not
 demand anything. It is impossible to "comply" to an informational
 document. This, of course, doesn't stop marketing guys from telling they

--- a/source/whitepapers/syslog_protocol.rst
+++ b/source/whitepapers/syslog_protocol.rst
@@ -205,7 +205,7 @@ be discussed ;)
    be used but UTF-8 is preferred. To detect UTF-8, the MSG should start
    with the UTF-8 byte order mask of "EF BB BF" if it is UTF-8 encoded
    (see section 155.9 of
-   `http://www.unicode.org/versions/Unicode4.0.0/ch15.pdf <http://www.unicode.org/versions/Unicode4.0.0/ch15.pdf>`_)
+   `https://www.unicode.org/versions/Unicode4.0.0/ch15.pdf <https://www.unicode.org/versions/Unicode4.0.0/ch15.pdf>`_)
 -  Requirements to drop messages should be reconsidered. I guess I would
    not be the only implementor ignoring them.
 -  Logging requirements should be reconsidered and probably be removed.

--- a/tools/buildenv/tools/git-clone
+++ b/tools/buildenv/tools/git-clone
@@ -9,5 +9,5 @@ if [ -e /rsyslog-doc/source ]; then
 	exit 1
 fi
 cd /
-git clone https://github.com/rsyslog/rsyslog-doc
+git clone https://github.com/rsyslog/rsyslog-doc.git
 (cd /rsyslog-doc; git checkout $BRANCH)


### PR DESCRIPTION
I started to check and correct URLs used in the docs.

I decided to do checks and fixes by domain / GitHub repository. And create small pull requests with a small list of these. I hope this way it is easier to review these changes, too.

the following domains and links where checked and fixed via this pull requests:
* changed an example url to `example.com`
* rsyslog/rsyslog-doc repository
* grafana/loki repository
* redis/hiredis repository
* `gerhards.net`
* `ietf.org`
* `openssl.org`
* `confluent.io`
* `debian.org`
* `redhat.com`
* `wikipedia.org`
* `facebook.com`
* `semver.org`
* `unicode.org`
* `adiscon.org`
* `tcpdump.org`
* `blogspot.com`
* `readthedocs.org`

Feel free to make any suggestions if you like these changes differently for the rsyslog-doc repository.