### PR TITLE
Replace sphinx pypi package with os py3 package

### DIFF
--- a/tools/buildenv/Dockerfile
+++ b/tools/buildenv/Dockerfile
@@ -1,7 +1,6 @@
-FROM	alpine
+FROM	alpine:3.20
 LABEL	maintainer rgerhards@adiscon.com
-RUN	apk add --no-cache py-pip git
-RUN	pip install sphinx
+RUN	apk add --no-cache git py3-sphinx
 RUN	adduser -s /bin/ash -D rsyslog rsyslog \
 	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 WORKDIR	/home/appliance

--- a/tools/buildenv/README.md
+++ b/tools/buildenv/README.md
@@ -2,7 +2,7 @@ build:
 
 docker build  -t rsyslog/rsyslog_doc_gen .
 
-where rsyslog/rsyslog_doc_gen is the tag and the location on dockerhub. Obviously,
+where rsyslog/rsyslog_doc_gen is the tag and the location on Docker Hub. Obviously,
 you need to use something else if you are not a maintainer of that repository.
 
 ENV VARS


### PR DESCRIPTION
I tried to build the Docker image via the provided Dockerfile and the build failed with the following error message
```
error: externally-managed-environment

× This environment is externally managed
╰─> 
    The system-wide python installation should be maintained using the system
    package manager (apk) only.
    
    If the package in question is not packaged already (and hence installable via
    "apk add py3-somepackage"), please consider installing it inside a virtual
    environment, e.g.:
    
    python3 -m venv /path/to/venv
    . /path/to/venv/bin/activate
    pip install mypackage
    
    To exit the virtual environment, run:
    
    deactivate
    
    The virtual environment is not deleted, and can be re-entered by re-sourcing
    the activate file.
    
    To automatically manage virtual environments, consider using pipx (from the
    pipx package).

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

Because of that, i replaced the installation of the pypi sphinx package with the os package `py3-sphinx`. And also used a tag for the Alpine Linux Docker image to make the build more reliable.

That worked for me. I also noticed some label issues #1064 resulting in a build error.