### PR TITLE
Correct queue.discardMark default value

### DIFF
--- a/source/rainerscript/queue_parameters.rst
+++ b/source/rainerscript/queue_parameters.rst
@@ -259,7 +259,7 @@ queue.discardMark
    :widths: auto
    :class: parameter-table
 
-   "integer", "80% of queue.size", "no", "``$ActionQueueDiscardMark``"
+   "integer", "98% of queue.size", "no", "``$ActionQueueDiscardMark``"
 
 Specifies the threshold at which rsyslog begins to discard less important
 messages. To define which messages should be discarded use the


### PR DESCRIPTION
According to https://github.com/rsyslog/rsyslog/blob/master/runtime/queue.c#L3334 , the default value of `queue.discardMark` is 98% of the overall queue size. This part of the doc has not been updated since the actual patch took place.