### PR TITLE
Regularize “a” vs “an” to match English phonetics

### DIFF
--- a/source/compatibility/v3compatibility.rst
+++ b/source/compatibility/v3compatibility.rst
@@ -110,7 +110,7 @@ compatibility mode (if no -c option is given). Use the ``$UDPSeverRun
 the server should listen to via ``$UDPServerAddress <ip>`` config
 directive.
 
-The following example configures an UDP syslog server at the local
+The following example configures a UDP syslog server at the local
 address 192.0.2.1 on port 514:
 
 ::

--- a/source/concepts/queues.rst
+++ b/source/concepts/queues.rst
@@ -165,7 +165,7 @@ In-memory queue mode is what most people have on their mind when they
 think about computing queues. Here, the enqueued data elements are held
 in memory. Consequently, in-memory queues are very fast. But of course,
 they do not survive any program or operating system abort (what usually
-is tolerable and unlikely). Be sure to use an UPS if you use in-memory
+is tolerable and unlikely). Be sure to use a UPS if you use in-memory
 mode and your log data is important to you. Note that even in-memory
 queues may hold data for an infinite amount of time when e.g. an output
 destination system is down and there is no reason to move the data out

--- a/source/configuration/global/options/rsconf1_abortonuncleanconfig.rst
+++ b/source/configuration/global/options/rsconf1_abortonuncleanconfig.rst
@@ -17,7 +17,7 @@ This parameter permits to prevent rsyslog from running when the
 configuration file is not clean. "Not Clean" means there are errors or
 some other annoyances that rsyslogd reports on startup. This is a
 user-requested feature to have a strict startup mode. Note that with the
-current code base it is not always possible to differentiate between an
+current code base it is not always possible to differentiate between a
 real error and a warning-like condition. As such, the startup will also
 prevented if warnings are present. I consider this a good thing in being
 "strict", but I admit there also currently is no other way of doing it.

--- a/source/configuration/modules/imfile.rst
+++ b/source/configuration/modules/imfile.rst
@@ -466,7 +466,7 @@ sequence. The default historically is inconsistent and depends on which
 functionality is used to read the file. It can be either "#012" or "\\n". If
 you want to retain that default, do not configure this parameter.
 
-If it is configured, any sequence may be used. For example, to replace a LF
+If it is configured, any sequence may be used. For example, to replace an LF
 with a simple space, use::
 
    escapeLF.replacement=" "

--- a/source/configuration/modules/imhiredis.rst
+++ b/source/configuration/modules/imhiredis.rst
@@ -226,7 +226,7 @@ uselpop
 
    "boolean", "no", "no", "none"
 
-| When using the :ref:`imhiredis_queue_mode`, defines if imhiredis should use a LPOP instruction instead of a RPOP (the default).
+| When using the :ref:`imhiredis_queue_mode`, defines if imhiredis should use an LPOP instruction instead of an RPOP (the default).
 | Has no influence on the :ref:`imhiredis_channel_mode` and will be ignored if set with this mode.
 
 

--- a/source/configuration/modules/imhttp.rst
+++ b/source/configuration/modules/imhttp.rst
@@ -238,7 +238,7 @@ basicAuthFile
    "string", "no", "none", ""
 
 Enables access control to this endpoint using http basic authentication. Option is disabled by default.
-To enable it, set this option to a `htpasswd file`, which can be generated using a standard `htpasswd` tool.
+To enable it, set this option to an `htpasswd file`, which can be generated using a standard `htpasswd` tool.
 
 See also:
 
@@ -260,7 +260,7 @@ basicAuthFile
 
    "string", "no", "none", "none"
 
-Configures a `htpasswd <https://httpd.apache.org/docs/2.4/programs/htpasswd.html>`_ file and enables `basic authentication <https://en.wikipedia.org/wiki/Basic_access_authentication>`_ on http request received on this input.
+Configures an `htpasswd <https://httpd.apache.org/docs/2.4/programs/htpasswd.html>`_ file and enables `basic authentication <https://en.wikipedia.org/wiki/Basic_access_authentication>`_ on http request received on this input.
 If this option is not set, basic authentication will not be enabled.
 
 
@@ -296,7 +296,7 @@ Examples
 Example 1
 ---------
 
-This sets up a http server instance on port 8080 with two inputs.
+This sets up an http server instance on port 8080 with two inputs.
 One input path at '/postrequest', and another at '/postrequest2':
 
 .. code-block:: none
@@ -337,7 +337,7 @@ One input path at '/postrequest', and another at '/postrequest2':
 Example 2
 ---------
 
-This sets up a http server instance on ports 80 and 443s (use 's' to indicate ssl) with an input path at '/postrequest':
+This sets up an http server instance on ports 80 and 443s (use 's' to indicate ssl) with an input path at '/postrequest':
 
 .. code-block:: none
 

--- a/source/configuration/modules/imptcp.rst
+++ b/source/configuration/modules/imptcp.rst
@@ -568,7 +568,7 @@ Experimental parameter. It is similar to "MultiLine", but provides greater
 control of when a log message ends. You can specify a regular expression that
 characterizes the header to expect at the start of the next message. As such,
 it indicates the end of the current message. For example, one can use this
-setting to use a RFC3164 header as frame delimiter::
+setting to use an RFC3164 header as frame delimiter::
 
     framing.delimiter.regex="^<[0-9]{1,3}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"
 

--- a/source/configuration/modules/imtuxedoulog.rst
+++ b/source/configuration/modules/imtuxedoulog.rst
@@ -12,7 +12,7 @@ Purpose
 =======
 
 This module allows rsyslog to process Tuxedo ULOG files.
-Tuxedo create an ULOG file each new log of the day this file is defined
+Tuxedo create a ULOG file each new log of the day this file is defined
 
 - a prefix configured in the tuxedo configuration
 

--- a/source/configuration/modules/imudp.rst
+++ b/source/configuration/modules/imudp.rst
@@ -411,7 +411,7 @@ The following properties are maintained for each listener:
 -  **submitted** - total number of messages submitted for processing since startup
 
 The worker thread (in short: worker) statistic is named "imudp(wX)" where "X" is
-the worker thread ID, which is an monotonically increasing integer starting at 0.
+the worker thread ID, which is a monotonically increasing integer starting at 0.
 This means the first worker will have the name "imudp(w0)", the second "imudp(w1)"
 and so on. Note that workers are all equal. It doesn’t really matter which worker
 processes which messages, so the actual worker ID is not of much concern. More
@@ -424,7 +424,7 @@ Note: worker thread statistics are available starting with rsyslog 7.5.5.
 -  **disallowed** - total number of messages discarded due to disallowed sender
 
 This counts the number of messages that have been discarded because they have
-been received by an disallowed sender. Note that if no allowed senders are
+been received by a disallowed sender. Note that if no allowed senders are
 configured (the default), this counter will always be zero.
 
 This counter was introduced by rsyslog 8.35.0.
@@ -453,7 +453,7 @@ Examples
 Example 1
 ---------
 
-This sets up an UDP server on port 514:
+This sets up a UDP server on port 514:
 
 .. code-block:: none
 

--- a/source/configuration/modules/mmrfc5424addhmac.rst
+++ b/source/configuration/modules/mmrfc5424addhmac.rst
@@ -84,7 +84,7 @@ development of a verification tool, please simply email
 
 **See Also**
 
--  `How to add a HMAC to RFC5424
+-  `How to add an HMAC to RFC5424
    messages <http://www.rsyslog.com/how-to-add-a-hmac-to-rfc5424-structured-data-messages/>`_
 
 **Caveats/Known Bugs:**

--- a/source/configuration/modules/omclickhouse.rst
+++ b/source/configuration/modules/omclickhouse.rst
@@ -255,7 +255,7 @@ Parameters are:
 -  **submitted** - number of messages submitted for processing (with both
    success and error result)
 
--  **fail.httprequests** - the number of times a http request failed. Note
+-  **fail.httprequests** - the number of times an http request failed. Note
    that a single http request may be used to submit multiple messages, so this
    number may be (much) lower than failed.http.
 

--- a/source/configuration/modules/omelasticsearch.rst
+++ b/source/configuration/modules/omelasticsearch.rst
@@ -799,7 +799,7 @@ Parameters are:
 -  **submitted** - number of messages submitted for processing (with both
    success and error result)
 
--  **fail.httprequests** - the number of times a http request failed. Note
+-  **fail.httprequests** - the number of times an http request failed. Note
    that a single http request may be used to submit multiple messages, so this
    number may be (much) lower than fail.http.
 

--- a/source/configuration/modules/ommail.rst
+++ b/source/configuration/modules/ommail.rst
@@ -209,7 +209,7 @@ need to load the external process (but that should be no problem given
 the expected infrequent number of calls into this plugin). The big
 advantage of sendmail mode is that it supports all the bells and
 whistles of a full-blown SMTP implementation and may even work for local
-delivery without a SMTP server being present. Sendmail mode will be
+delivery without an SMTP server being present. Sendmail mode will be
 implemented as need arises. So if you need it, please drop us a line (If
 nobody does, sendmail mode will probably never be implemented).
 

--- a/source/configuration/modules/ompipe.rst
+++ b/source/configuration/modules/ompipe.rst
@@ -20,7 +20,7 @@ Note: parameter names are case-insensitive.
 Note: parameter names are case-insensitive.
 
 -  Pipe: string a fifo or named pipe can be used as a destination for log messages.
--  tryResumeReopen: Sometimes we need to reopen a pipe after an ompipe action gets suspended. Sending an HUP signal does the job but requires an interaction with rsyslog. When set to "on" and a resume action fails, the file descriptor is closed, causing a new open in the next resume. Default: "off" to preserve existing behavior before introduction of this option.
+-  tryResumeReopen: Sometimes we need to reopen a pipe after an ompipe action gets suspended. Sending a HUP signal does the job but requires an interaction with rsyslog. When set to "on" and a resume action fails, the file descriptor is closed, causing a new open in the next resume. Default: "off" to preserve existing behavior before introduction of this option.
 
 **Caveats/Known Bugs:**
 None

--- a/source/configuration/output_channels.rst
+++ b/source/configuration/output_channels.rst
@@ -39,7 +39,7 @@ there are no special symbols (like 1k, 1m,...) at this point of
 development.
 Keep in mind that $outchannel just defines a channel with "name". It
 does not activate it. To do so, you must use a selector line (see
-below). That selector line includes the channel name plus an $ sign in
+below). That selector line includes the channel name plus a $ sign in
 front of it. A sample might be:
 \*.\* :omfile:$mychannel
 In its current form, output channels primarily provide the ability to

--- a/source/configuration/rsyslog-example.conf
+++ b/source/configuration/rsyslog-example.conf
@@ -61,10 +61,10 @@ $template MyTemplateName,"\7Text %property% some more text\n",
 # \ = \\
 
 # Template options are case-insensitive. Currently defined are:
-# sql      format the string suitable for a SQL statement. This will replace single
+# sql      format the string suitable for an SQL statement. This will replace single
 #          quotes ("'") by two single quotes ("''") to prevent the SQL injection 
 #          (NO_BACKSLASH_ESCAPES turned off)
-# stdsql - format the string suitable for a SQL statement that is to
+# stdsql - format the string suitable for an SQL statement that is to
 #          be sent  to  a standards-compliant sql server. 
 #          (NO_BACKSLASH_ESCAPES turned on)
 

--- a/source/configuration/sysklogd_format.rst
+++ b/source/configuration/sysklogd_format.rst
@@ -24,7 +24,7 @@ Lines starting with a hash mark ("#") and empty lines are ignored.
 
 This variant of syslogd is able to understand a slightly extended syntax
 compared to the original BSD syslogd. One rule may be divided into several
-lines if the leading line is terminated with an backslash ("\\").
+lines if the leading line is terminated with a backslash ("\\").
 
 SELECTORS
 =========

--- a/source/configuration/templates.rst
+++ b/source/configuration/templates.rst
@@ -437,14 +437,14 @@ the latter ones are processed by the property replacer and apply to a
 SINGLE property, only (and not the whole template).
 Template options are case-insensitive. Currently defined are:
 
-**option.sql** - format the string suitable for a SQL statement in MariaDB/
+**option.sql** - format the string suitable for an SQL statement in MariaDB/
 MySQL format. This will replace single quotes ("'") and the backslash
 character by their backslash-escaped counterpart ("\\'" and "\\\\")
 inside each field. Please note that in MySQL configuration, the
 ``NO_BACKSLASH_ESCAPES`` mode must be turned off for this format to work
 (this is the default).
 
-**option.stdsql** - format the string suitable for a SQL statement that
+**option.stdsql** - format the string suitable for an SQL statement that
 is to be sent to a standards-compliant sql server. This will replace
 single quotes ("'") by two single quotes ("''") inside each field. You
 must use stdsql together with MySQL if in MySQL configuration the

--- a/source/configuration/timezone.rst
+++ b/source/configuration/timezone.rst
@@ -8,7 +8,7 @@ The ``timezone`` object, as its name suggests, describes timezones.
 Currently, they are used by message parser modules to interpret
 timestamps that contain timezone information via a timezone string
 (but not an offset, e.g. "CET" but not "-01:00"). The object describes
-an UTC offset for a given timezone ID.
+a UTC offset for a given timezone ID.
 
 Each timestamp object adds the zone definition to a global table
 with timezone information. Duplicate IDs are forbidden, but the

--- a/source/development/dev_queue.rst
+++ b/source/development/dev_queue.rst
@@ -90,7 +90,7 @@ fully initialized. If not, it initializes it, what most importantly
 means construction of the queue.
 
 Then, regular worker processing is carried out. That is, the queue
-worker will wait on empty queue and terminate after an timeout. However,
+worker will wait on empty queue and terminate after a timeout. However,
 If any message is received, the DA consumer is executed. That consumer
 checks the low water mark. If the low water mark is reached, it stops
 processing until either the high water mark is reached again or the DA

--- a/source/development/generic_design.rst
+++ b/source/development/generic_design.rst
@@ -77,7 +77,7 @@ benefit from knowing the generic architecture.
 -  A "PLOrig" is a payload originator residing within the syslog
    application itself. Typically, this PLOrig emits syslog application
    startup, shutdown, error and status log messages.
--  A "GWI" is a inbound gateway. For example, a SNMP-to-syslog gateway
+-  A "GWI" is a inbound gateway. For example, an SNMP-to-syslog gateway
    may receive SNMP messages and translate them into syslog.
 -  The ellipsis after "GWI" indicates that there are potentially a
    variety of different other ways to originally generate payload.

--- a/source/historical/stunnel.rst
+++ b/source/historical/stunnel.rst
@@ -15,7 +15,7 @@ Abstract
 **In this paper, I describe how to encrypt**
 `syslog <http://www.monitorware.com/en/topics/syslog/>`_ **messages on the
 network.** Encryption is vital to keep the confidential content of
-syslog messages secure. I describe the overall approach and provide an
+syslog messages secure. I describe the overall approach and provide a
 HOWTO do it with the help of `rsyslogd <http://www.rsyslog.com>`_ and
 `stunnel <http://www.stunnel.org>`_.*
 

--- a/source/rainerscript/functions/mo-http_request.rst
+++ b/source/rainerscript/functions/mo-http_request.rst
@@ -7,7 +7,7 @@ Purpose
 
 http_request(str)
 
-Performs a http request to target and returns the result of said request.
+Performs an http request to target and returns the result of said request.
 
 .. note::
 
@@ -18,7 +18,7 @@ Performs a http request to target and returns the result of said request.
 Example
 =======
 
-The following example performs a http request and writes the returned value
+The following example performs an http request and writes the returned value
 to a file.
 
 

--- a/source/rainerscript/global.rst
+++ b/source/rainerscript/global.rst
@@ -545,7 +545,7 @@ The following parameters can be set:
   configuration file is not clean. "Not Clean" means there are errors or
   some other annoyances that rsyslogd reports on startup. This is a
   user-requested feature to have a strict startup mode. Note that with the
-  current code base it is not always possible to differentiate between an
+  current code base it is not always possible to differentiate between a
   real error and a warning-like condition. As such, the startup will also
   prevented if warnings are present. I consider this a good thing in being
   "strict", but I admit there also currently is no other way of doing it.
@@ -610,7 +610,7 @@ The following parameters can be set:
 
 - **security.abortOnIDResolutionFail** [boolean (on/off)], default "on", available 8.2002.0+
 
-  This setting controls if rsyslog should error-terminate when an security ID cannot
+  This setting controls if rsyslog should error-terminate when a security ID cannot
   be resolved during config file processing at startup. If set to "on" and
   a name ID lookup fails (for user and group names) rsyslog does not start but
   terminate with an error message. This is necessary as a security

--- a/source/troubleshooting/troubleshoot.rst
+++ b/source/troubleshooting/troubleshoot.rst
@@ -372,7 +372,7 @@ better, and thus be able to quicker craft a fix.
 
 In order to get useful information, we need some backtrace of the abort.
 First, you need to make sure that a core file is created. Under Fedora,
-for example, that means you need to have an "ulimit -c unlimited" in
+for example, that means you need to have a "ulimit -c unlimited" in
 place.
 
 Now let's assume you got a core file (e.g. in /core.1234). So what to do

--- a/source/tutorials/database.rst
+++ b/source/tutorials/database.rst
@@ -110,7 +110,7 @@ Replacer <http://www.rsyslog.com/doc-property_replacer.html>`_\ ".
 Simply said, you access properties by including their name between
 percent signs inside the template. For example, if the syslog message is
 "Test", the template "%msg%" would be expanded to "Test". Rsyslogd
-supports sending template text as a SQL statement to the database. As
+supports sending template text as an SQL statement to the database. As
 such, the template must be a valid SQL statement. There is no limit in
 what the statement might be, but there are some obvious and not so
 obvious choices. For example, a template "drop table xxx" is possible,

--- a/source/tutorials/tls.rst
+++ b/source/tutorials/tls.rst
@@ -11,7 +11,7 @@ Abstract
 `syslog <http://www.monitorware.com/en/topics/syslog/>`_ 
 **messages on the network.**
 Encryption is vital to keep the confidential content of
-syslog messages secure. I describe the overall approach and provide an
+syslog messages secure. I describe the overall approach and provide a
 HOWTO do it with `rsyslog's <http://www.rsyslog.com>`_ TLS features. 
 
 Please note that TLS is the more secure successor of SSL. While people
@@ -51,7 +51,7 @@ tcp over TLS for a while now. While I am not fully satisfied with the
 results so far, this obviously has the  potential to become the
 long-term solution. The Internet Draft in question, syslog-transport-tls
 has been dormant for some time but is now (May of 2008) again being
-worked on. I expect it to turn into a RFC within the next 12 month (but
+worked on. I expect it to turn into an RFC within the next 12 month (but
 don't take this for granted ;)). I didn't want to wait for it, because
 there obviously is need for TLS syslog right now (and, honestly, I have
 waited long enough...). Consequently, I have implemented the current

--- a/source/whitepapers/syslog_protocol.rst
+++ b/source/whitepapers/syslog_protocol.rst
@@ -170,7 +170,7 @@ This lists what has been found during implementation:
 -  As an architectural side-effect, syslog-protocol formatted messages
    can also be transmitted over non-standard syslog/raw tcp. This
    implementation uses the industry-standard LF termination of tcp
-   syslog records. As such, syslog-protocol messages containing a LF
+   syslog records. As such, syslog-protocol messages containing an LF
    will be broken invalidly. There is nothing that can be done against
    this without specifying a TCP transport. This issue might be more
    important than one thinks on first thought. The reason is the wide


### PR DESCRIPTION
In most dialects of English the rule to choose _a_ vs _an_ is to listen to the first sound of the following word (as it is _spoken_): _a_ before a consonant sound, including _h_ and _y_, and _an_ before a vowel sound.

Initialisms are read as the names of the letters, and it is important to note that the names of some consonants start with a vowel sound, while the names of some vowels start with a consonant sound:

|Initial|Read as|
|---|---|
|F|_an eff_|
|H|_an aitch_ *|
|L|_an ell_|
|M|_an em_|
|N|_an en_|
|R|_an are_|
|S|_an ess_|
|U|_a you_|
|Y|_a why_|

 * some dialects prefer _a haitch_, especially in Australia