### PR TITLE
2nd omjournal sample code with subtree template supporting expressions

### DIFF
--- a/source/configuration/modules/omjournal.rst
+++ b/source/configuration/modules/omjournal.rst
@@ -57,15 +57,18 @@ Example 1
 The following sample writes all syslog messages to the journal with a
 custom EVENT_TYPE field.
 
-.. code-block:: none
+.. code-block:: shell
 
    module(load="omjournal")
 
    template(name="journal" type="list") {
-     constant(value="Something happened" outname="MESSAGE")
-     property(name="$!event-type" outname="EVENT_TYPE")
+     # Emulate default journal fields
+     property(name="msg" outname="MESSAGE")
+     property(name="timestamp" outname="SYSLOG_TIMESTAMP")
+     property(name="syslogfacility" outname="SYSLOG_FACILITY")
+     property(name="syslogseverity" outname="PRIORITY")
+
+     constant(value="strange" outname="EVENT_TYPE")
    }
 
    action(type="omjournal" template="journal")
-
-

--- a/source/configuration/modules/omjournal.rst
+++ b/source/configuration/modules/omjournal.rst
@@ -55,7 +55,7 @@ Example 1
 ---------
 
 The following sample writes all syslog messages to the journal with a
-custom EVENT_TYPE field.
+custom EVENT_TYPE field and to override journal's default *identifier* (which by default will be ``rsyslogd``):
 
 .. code-block:: shell
 
@@ -68,7 +68,9 @@ custom EVENT_TYPE field.
      property(name="syslogfacility" outname="SYSLOG_FACILITY")
      property(name="syslogseverity" outname="PRIORITY")
 
+     # Custom fields
      constant(value="strange" outname="EVENT_TYPE")
+     constant(value="router" outname="SYSLOG_IDENTIFIER")
    }
 
    action(type="omjournal" template="journal")

--- a/source/configuration/modules/omjournal.rst
+++ b/source/configuration/modules/omjournal.rst
@@ -74,3 +74,30 @@ custom EVENT_TYPE field and to override journal's default *identifier* (which by
    }
 
    action(type="omjournal" template="journal")
+
+
+Example 2
+---------
+
+The :doc:`subtree` template is a better fit for structured outputs like this, allowing arbitrary expressions for the destination journal fields using :doc:`set` & :doc:`reset` directives in *rulsets*.  For instance, here the captured *tags* are translated with :doc:`Lookup Tables`
+(to facilitae filtering with ``journalctl -t <TAG>``):
+
+.. code-block:: shell
+
+   module(load="omjournal")
+
+   template(name="journal-subtree" type="subtree" subtree="$!")
+
+   lookup_table("tags", ...)
+
+   ruleset(name="journal") {
+     # Emulate default journal fields
+     set $!MESSAGE = $msg;
+     set $!SYSLOG_TIMESTAMP = $timestamp;
+     set $!SYSLOG_FACILITY = $syslogfacility;
+     set $!PRIORITY = $syslogseverity
+
+     set $!SYSLOG_IDENTIFIER = lookup("tags", $hostname-ip);
+
+     action(type="omjournal" template="journal-subtree")
+   }


### PR DESCRIPTION
The regular template directive does not work with data expressions (rsyslog/rsyslog#5571) so the `subtree` template is a better fit for `omjournal` structured output.