### PR TITLE
Fix im3195 documentation

### DIFF
--- a/source/configuration/modules/im3195.rst
+++ b/source/configuration/modules/im3195.rst
@@ -43,7 +43,7 @@ Input3195ListenPort
 
    "integer", "601", "no", "``$Input3195ListenPort``"
 
-The port on which imklog listens for RFC 3195 messages. The default
+The port on which im3195 listens for RFC 3195 messages. The default
 port is 601 (the IANA-assigned port)
 
 


### PR DESCRIPTION
## Summary
- fix wrong reference to imklog in im3195 module docs

## Testing
- `sphinx-build -b html source build`

------
https://chatgpt.com/codex/tasks/task_e_68428db166d48332a9250d0f8746feef