### PR TITLE
Add markdown build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+build_markdown
 source/_build
 .project
 .vscode

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ later steps are identical, so those steps have been covered in one place.
     1. `sphinx-build -b html source build`
 1. Generate EPUB format
     1. `sphinx-build -b epub source build`
+1. Generate Markdown format (requires `pandoc`)
+    1. `./tools/build_markdown.sh`
+    - The resulting `rsyslog-doc.md` file is written to `build_markdown/`.
 1. Review generated contents
     - Open rsyslog-doc/build/index.html in a browser
     - Use Calibre, Microsoft Edge, Okular, Google Play Books or any other

--- a/tools/build_markdown.sh
+++ b/tools/build_markdown.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Build single-page HTML from the Sphinx sources and convert it to Markdown
+# for AI ingestion.
+
+set -euo pipefail
+
+command -v pandoc >/dev/null 2>&1 || {
+    echo "[!] pandoc is required but not installed" >&2
+    exit 1
+}
+
+BUILD_DIR="build_markdown"
+HTML_DIR="$BUILD_DIR/singlehtml"
+MD_FILE="$BUILD_DIR/rsyslog-doc.md"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$HTML_DIR"
+
+# Build single-page HTML
+sphinx-build -b singlehtml source "$HTML_DIR"
+
+# Convert HTML to Markdown
+pandoc "$HTML_DIR/index.html" -f html -t gfm -o "$MD_FILE"
+
+echo "Markdown output written to $MD_FILE"


### PR DESCRIPTION
## Summary
- add a helper script that builds singlehtml and converts it to Markdown
- document how to generate Markdown output
- ignore the build_markdown directory

## Testing
- `./tools/build_markdown.sh`

------
https://chatgpt.com/codex/tasks/task_e_68457f69317c8332981f87c23afe0e46