### PR TITLE
Add Makefile for Sphinx builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Makefile for rsyslog-doc
+#
+# You can set these variables from the command line.
+SPHINXOPTS ?=
+SPHINXBUILD ?= sphinx-build
+SOURCEDIR = source
+BUILDDIR = build
+
+.PHONY: help clean html
+
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf "$(BUILDDIR)"
+
+html:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+%:
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
## Summary
- add a simple Makefile with `html` and `clean`
- users can still access other builders via catch-all target

## Testing
- `make clean`
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_684922e62c04833288636c0b78405019